### PR TITLE
Add reusable repo-backup-to-s3 workflow

### DIFF
--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -1,0 +1,95 @@
+name: Repo Backup to S3
+
+on:
+  workflow_call:
+    inputs:
+      s3-bucket:
+        description: S3 bucket name to upload the backup to
+        type: string
+        required: true
+      s3-prefix:
+        description: Key prefix (folder) within the bucket (defaults to repo name)
+        type: string
+        default: ""
+      aws-region:
+        description: AWS region of the S3 bucket
+        type: string
+        default: "us-east-1"
+      environment:
+        description: GitHub environment whose secrets contain AWS_ROLE_ARN
+        type: string
+        default: "production"
+  workflow_dispatch:
+    inputs:
+      s3-bucket:
+        description: S3 bucket name to upload the backup to
+        type: string
+        required: true
+      s3-prefix:
+        description: Key prefix (folder) within the bucket (defaults to repo name)
+        type: string
+        default: ""
+      aws-region:
+        description: AWS region of the S3 bucket
+        type: string
+        default: "us-east-1"
+      environment:
+        description: GitHub environment whose secrets contain AWS_ROLE_ARN
+        type: string
+        default: "production"
+
+jobs:
+  backup:
+    name: Backup to S3
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve inputs
+        id: vars
+        run: |
+          REPO_NAME="${{ github.event.repository.name }}"
+          PREFIX="${{ inputs.s3-prefix }}"
+          if [ -z "$PREFIX" ]; then
+            PREFIX="$REPO_NAME"
+          fi
+          DATE=$(date -u +%Y-%m-%d)
+          SHA="${{ github.sha }}"
+          FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
+          echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+          echo "s3-key=${PREFIX}/${FILENAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Create zip archive
+        run: |
+          git archive --format=zip --output="${{ steps.vars.outputs.filename }}" HEAD
+          SIZE=$(du -sh "${{ steps.vars.outputs.filename }}" | cut -f1)
+          echo "ARCHIVE_SIZE=$SIZE" >> "$GITHUB_ENV"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp "${{ steps.vars.outputs.filename }}" \
+            "s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}"
+
+      - name: Write job summary
+        run: |
+          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| S3 URI | \`s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/repo-backup.yml` — a reusable `workflow_call` workflow (plus `workflow_dispatch` for manual runs) that backs up any calling repo to S3 as a zip archive
- Uses `git archive` so only tracked files are included (respects `.gitignore`)
- Archive filename format: `{repo}-{YYYY-MM-DD}-{short-sha}.zip`
- AWS credentials via OIDC — resolves `AWS_ROLE_ARN` from the calling repo's GitHub environment secret, supporting different AWS accounts per repo
- Writes a summary table with S3 URI and archive size to the job summary

## Usage

```yaml
jobs:
  backup:
    uses: Specter099/.github/.github/workflows/repo-backup.yml@main
    secrets: inherit
    with:
      s3-bucket: my-backups-bucket
      # environment defaults to "production"
      # s3-prefix defaults to repo name
      # aws-region defaults to us-east-1
```

Each repo needs `AWS_ROLE_ARN` set as an environment secret in the specified environment, pointing to a role with `s3:PutObject` on the target bucket.

## Test plan

- [ ] Call the workflow from a test repo with a valid bucket and role — confirm zip appears in S3 with the expected key
- [ ] Confirm the job summary shows the correct S3 URI and file size
- [ ] Test with a custom `s3-prefix` and non-default `environment`
- [ ] Confirm a missing/invalid `AWS_ROLE_ARN` fails fast at the credentials step

🤖 Generated with [Claude Code](https://claude.com/claude-code)