### PR TITLE
feat: add reusable gitleaks secret scanning workflow

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -16,6 +16,12 @@ on:
         type: string
         default: ""
 jobs:
+  gitleaks:
+    name: Secret Scan
+    uses: Specter099/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+
   review:
     name: Synth & Diff
     runs-on: ubuntu-latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,20 @@
+name: Gitleaks
+
+on:
+  workflow_call:
+
+jobs:
+  gitleaks:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: ruff format --check .
 
       - name: Secrets scan (gitleaks)
-        uses: zricethezav/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Add standalone `gitleaks.yml` reusable workflow that any repo can call
- Wire gitleaks into `cdk-review.yml` as a parallel job (Secret Scan runs alongside Synth & Diff)
- Update `python-ci.yml` to use official `gitleaks/gitleaks-action@v2` (migrated from deprecated `zricethezav` org)

## Test plan
- [ ] Verify `gitleaks.yml` is callable as a reusable workflow
- [ ] Verify `cdk-review.yml` runs Secret Scan in parallel with Synth & Diff
- [ ] Verify `python-ci.yml` gitleaks step still works with updated action reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)