### PR TITLE
fix: treat pytest exit code 5 (no tests) as success

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -53,7 +53,12 @@ jobs:
         if: hashFiles('tests/') != '' && success()
         run: |
           if command -v pytest &> /dev/null; then
-            pytest tests/ -v
+            pytest tests/ -v || rc=$?
+            if [ "${rc:-0}" -eq 5 ]; then
+              echo "::notice::no tests collected — skipping"
+            elif [ "${rc:-0}" -ne 0 ]; then
+              exit "$rc"
+            fi
           else
             echo "::notice::pytest not installed — skipping tests"
           fi


### PR DESCRIPTION
## Summary
- Pytest exit code 5 means "no tests collected" — this happens when a `tests/` dir exists but contains no test files
- Currently this fails the workflow unnecessarily (e.g. ai-powered-network-operations)
- This change treats exit code 5 as a notice rather than a failure, while still failing on real test errors

## Test plan
- [ ] Repo with empty `tests/` dir should pass with a notice
- [ ] Repo with actual test failures should still fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)