### PR TITLE
fix: make AWS credentials optional in cdk-review workflow

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -15,6 +15,10 @@ on:
         description: URL to curl after deploy (optional)
         type: string
         default: ""
+    secrets:
+      AWS_ROLE_ARN:
+        description: IAM role ARN for OIDC federation (optional — skips synth/diff if absent)
+        required: false
 jobs:
   gitleaks:
     name: Secret Scan
@@ -72,18 +76,22 @@ jobs:
           fi
 
       - name: Configure AWS credentials
+        if: secrets.AWS_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: CDK Synth
+        if: secrets.AWS_ROLE_ARN != ''
         run: cdk synth
 
       - name: CDK Nag (informational)
+        if: secrets.AWS_ROLE_ARN != ''
         run: CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" || true
 
       - name: CDK Diff
+        if: secrets.AWS_ROLE_ARN != ''
         id: diff
         run: |
           diff_output=$(cdk diff 2>&1) || true
@@ -95,6 +103,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment diff on PR
+        if: secrets.AWS_ROLE_ARN != ''
         uses: actions/github-script@v7
         env:
           DIFF: ${{ steps.diff.outputs.diff }}
@@ -125,3 +134,7 @@ jobs:
                 body,
               });
             }
+
+      - name: AWS credentials not configured
+        if: secrets.AWS_ROLE_ARN == ''
+        run: echo "::warning::AWS_ROLE_ARN secret not set — skipping synth/diff"


### PR DESCRIPTION
## Summary
- Declare `AWS_ROLE_ARN` as an optional secret in `workflow_call`
- Gate all AWS-dependent steps (credentials, synth, nag, diff, PR comment) on `secrets.AWS_ROLE_ARN != ''`
- Emit a warning annotation when the secret is absent so it's visible but non-blocking
- Repos without AWS OIDC configured will now pass linting/tests instead of failing on credentials

## Affected repos
github-runner, resource-endpoints, access-analyzer-pipeline, nist-800-53-security-hub-cdk, frr-cdk, workspaces-secure-browser-cdk, spoof-cdn-cdk, and others without `AWS_ROLE_ARN`

## Test plan
- [ ] Repo with `AWS_ROLE_ARN` set still runs full synth/diff pipeline
- [ ] Repo without `AWS_ROLE_ARN` passes with a warning annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)