### PR TITLE
fix: add pull-requests read permission for gitleaks

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -21,6 +21,7 @@ jobs:
     uses: Specter099/.github/.github/workflows/gitleaks.yml@main
     permissions:
       contents: read
+      pull-requests: read
 
   review:
     name: Synth & Diff

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Gitleaks action needs `pull-requests: read` to fetch PR commits via the GitHub API
- Without it, the action fails with `403: Resource not accessible by integration`
- Added the permission to both `gitleaks.yml` and the caller job in `cdk-review.yml`

## Test plan
- [ ] Gitleaks job passes on repos using the reusable workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)