### PR TITLE
feat: add CloudFormation template scan mode to bucket name validator

### DIFF
--- a/.github/workflows/validate-bucket-names.yml
+++ b/.github/workflows/validate-bucket-names.yml
@@ -11,6 +11,13 @@ on:
         description: Directory to scan for bucket names
         type: string
         default: "."
+      template-dir:
+        description: >
+          Directory containing synthesized CloudFormation *.template.json files
+          (e.g. cdk.out). When provided, scans templates instead of (or in
+          addition to) Python source. Omit to use Python source scan only.
+        type: string
+        default: ""
 
 jobs:
   validate-bucket-names:
@@ -37,7 +44,14 @@ jobs:
 
       - name: Validate S3 bucket names
         id: validate
-        run: python .shared-github/scripts/validate_bucket_names.py --path ${{ inputs.scan-path }}
+        env:
+          SCAN_PATH: ${{ inputs.scan-path }}
+          TEMPLATE_DIR: ${{ inputs.template-dir }}
+        run: |
+          args=()
+          [ -n "$SCAN_PATH" ]    && args+=(--path "$SCAN_PATH")
+          [ -n "$TEMPLATE_DIR" ] && args+=(--template-dir "$TEMPLATE_DIR")
+          python .shared-github/scripts/validate_bucket_names.py "${args[@]}"
 
       - name: Comment on PR (violations only)
         if: failure() && github.event_name == 'pull_request'

--- a/scripts/validate_bucket_names.py
+++ b/scripts/validate_bucket_names.py
@@ -27,6 +27,7 @@ Exit codes:
 
 import argparse
 import ast
+import json
 import re
 import sys
 from pathlib import Path
@@ -40,9 +41,7 @@ from pathlib import Path
 #   region      : standard AWS region format  e.g. us-east-1, ap-southeast-2
 #   suffix      : literal "an"
 # ---------------------------------------------------------------------------
-BUCKET_NAME_RE = re.compile(
-    r"^[a-z0-9][a-z0-9-]+-\d{12}-[a-z]{2}-[a-z]+-\d-an$"
-)
+BUCKET_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]+-\d{12}-[a-z]{2}-[a-z]+-\d-an$")
 
 
 def is_valid_bucket_name(name: str) -> bool:
@@ -85,7 +84,10 @@ def scan_directory(root: Path) -> tuple[list[tuple[Path, int, str]], int]:
 
     for py_file in sorted(root.rglob("*.py")):
         parts = py_file.parts
-        if any(p in parts for p in ("cdk.out", ".venv", "venv", "node_modules", "__pycache__")):
+        if any(
+            p in parts
+            for p in ("cdk.out", ".venv", "venv", "node_modules", "__pycache__")
+        ):
             continue
 
         names = extract_bucket_names_from_file(py_file)
@@ -97,12 +99,54 @@ def scan_directory(root: Path) -> tuple[list[tuple[Path, int, str]], int]:
     return violations, checked
 
 
+def scan_templates(template_dir: Path) -> tuple[list[tuple[Path, str, str]], int]:
+    """
+    Scan CloudFormation *.template.json files for AWS::S3::Bucket resources
+    with a literal-string BucketName property and validate each name.
+
+    Returns (violations, checked_count).
+    Each violation is (template_path, logical_id, bucket_name).
+    """
+    skip = {"manifest.json", "tree.json"}
+    violations = []
+    checked = 0
+
+    for tpl_path in sorted(template_dir.rglob("*.template.json")):
+        if tpl_path.name in skip or tpl_path.name.startswith("asset."):
+            continue
+        try:
+            template = json.loads(tpl_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"  Warning: Could not parse {tpl_path.name}: {exc}", file=sys.stderr)
+            continue
+
+        for logical_id, resource in template.get("Resources", {}).items():
+            if resource.get("Type") != "AWS::S3::Bucket":
+                continue
+            bucket_name = resource.get("Properties", {}).get("BucketName")
+            if bucket_name is None or not isinstance(bucket_name, str):
+                # No explicit name (auto-generated) or intrinsic function — skip
+                continue
+            checked += 1
+            if not is_valid_bucket_name(bucket_name):
+                violations.append((tpl_path, logical_id, bucket_name))
+
+    return violations, checked
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate S3 bucket names in CDK Python source.")
+    parser = argparse.ArgumentParser(
+        description="Validate S3 bucket names in CDK source or synthesized templates."
+    )
     parser.add_argument(
         "--path",
-        default=".",
-        help="Root directory to scan (default: current directory)",
+        default=None,
+        help="Root directory to scan for bucket_name= in Python source files",
+    )
+    parser.add_argument(
+        "--template-dir",
+        default=None,
+        help="Directory containing CloudFormation *.template.json files (e.g. cdk.out)",
     )
     parser.add_argument(
         "--quiet",
@@ -111,33 +155,65 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    root = Path(args.path).resolve()
-    if not root.is_dir():
-        print(f"Error: Path not found or not a directory: {root}", file=sys.stderr)
-        return 1
+    if not args.path and not args.template_dir:
+        parser.error(
+            "Provide --path (Python source scan) or --template-dir (CF template scan), or both."
+        )
 
-    print(f"Scanning {root} for S3 bucket_name= arguments...")
-    violations, checked = scan_directory(root)
+    total_violations = 0
 
-    print(f"   Found {checked} hardcoded bucket name(s) across all .py files.\n")
+    if args.template_dir:
+        tdir = Path(args.template_dir).resolve()
+        if not tdir.is_dir():
+            print(f"Error: --template-dir not found: {tdir}", file=sys.stderr)
+            return 1
+        print(f"Scanning CloudFormation templates in {tdir} ...")
+        tpl_violations, tpl_checked = scan_templates(tdir)
+        if tpl_violations:
+            total_violations += len(tpl_violations)
+            print(f"\n{len(tpl_violations)} bucket name violation(s) in templates:\n")
+            print("   Required pattern: {prefix}-{12-digit-account-id}-{aws-region}-an")
+            print("   Example:          bitwarden-logs-123456789012-us-east-1-an\n")
+            for tpl_path, logical_id, name in tpl_violations:
+                print(f"   {tpl_path.name} / {logical_id}")
+                print(f'     BucketName = "{name}"')
+                print()
+        elif not args.quiet:
+            print(f"   Checked {tpl_checked} explicit bucket name(s) — all conform.")
 
-    if not violations:
-        if not args.quiet:
+    if args.path:
+        root = Path(args.path).resolve()
+        if not root.is_dir():
+            print(f"Error: --path not found: {root}", file=sys.stderr)
+            return 1
+        print(f"\nScanning {root} for S3 bucket_name= arguments...")
+        src_violations, src_checked = scan_directory(root)
+        print(
+            f"   Found {src_checked} hardcoded bucket name(s) across all .py files.\n"
+        )
+        if src_violations:
+            total_violations += len(src_violations)
+            print(f"{len(src_violations)} bucket name violation(s) found:\n")
+            print("   Required pattern: {prefix}-{12-digit-account-id}-{aws-region}-an")
+            print("   Example:          bitwarden-logs-123456789012-us-east-1-an\n")
+            for file_path, lineno, name in src_violations:
+                rel = (
+                    file_path.relative_to(root)
+                    if file_path.is_relative_to(root)
+                    else file_path
+                )
+                print(f"   {rel}:{lineno}")
+                print(f'     bucket_name = "{name}"')
+                print()
+        elif not args.quiet:
             print("All bucket names conform to the naming convention.")
             print("   Pattern: {prefix}-{12-digit-account-id}-{aws-region}-an")
-        return 0
 
-    print(f"{len(violations)} bucket name violation(s) found:\n")
-    print("   Required pattern: {prefix}-{12-digit-account-id}-{aws-region}-an")
-    print("   Example:          bitwarden-logs-123456789012-us-east-1-an\n")
-
-    for file_path, lineno, name in violations:
-        rel = file_path.relative_to(root) if file_path.is_relative_to(root) else file_path
-        print(f"   {rel}:{lineno}")
-        print(f'     bucket_name = "{name}"')
-        print()
-
-    return 1
+    if total_violations > 0:
+        return 1
+    if not args.quiet:
+        print("All checked bucket names pass.")
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `--template-dir` flag to `validate_bucket_names.py` to scan synthesized `*.template.json` files for `AWS::S3::Bucket` resources with explicit `BucketName` values
- Updates `validate-bucket-names.yml` workflow with a new `template-dir` input so CDK repos can run validation post-synth against `cdk.out`
- Both `--path` (Python source scan) and `--template-dir` (CF template scan) can be used together

## How it works

The script finds every `AWS::S3::Bucket` in CloudFormation templates where `Properties.BucketName` is a **literal string** and validates it against the naming convention. It skips:
- Buckets with no `BucketName` (CDK auto-generated names — can't validate at synth time)
- Buckets where `BucketName` is an intrinsic function like `{"Fn::Sub": ...}` (dynamic values)

## Usage after this PR

**Post-synth validation only:**
```yaml
uses: Specter099/.github/.github/workflows/validate-bucket-names.yml@main
with:
  scan-path: ""          # skip Python source scan
  template-dir: cdk.out  # scan synthesized templates
```

**Both scans:**
```yaml
with:
  scan-path: "."
  template-dir: cdk.out
```

**Existing callers (no change needed):** The `scan-path` default remains `"."`, so existing callers that omit both inputs continue to get the Python source scan unchanged.

## Test plan

- [ ] Confirm a template with `BucketName: "my-bucket"` fails
- [ ] Confirm a template with `BucketName: "app-123456789012-us-east-1-an"` passes
- [ ] Confirm a bucket with no `BucketName` property is skipped (no false positive)
- [ ] Confirm a bucket with `BucketName: {"Fn::Sub": "..."}` is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)