### PR TITLE
fix: replace required secret with environment input

### DIFF
--- a/.github/workflows/access-analyzer-check.yml
+++ b/.github/workflows/access-analyzer-check.yml
@@ -22,10 +22,12 @@ on:
         description: Fail the job when public access is detected (set false for warn-only)
         type: boolean
         default: true
-    secrets:
-      AWS_ROLE_ARN:
-        description: IAM role ARN to assume via OIDC (must allow access-analyzer:CheckNoPublicAccess)
-        required: true
+      environment:
+        description: >-
+          GitHub environment to deploy into. The environment must have an AWS_ROLE_ARN
+          secret set to the IAM role ARN to assume via OIDC.
+        type: string
+        default: production
 
 permissions:
   id-token: write  # OIDC token for AWS authentication
@@ -35,6 +37,7 @@ jobs:
   check-no-public-access:
     name: Check No Public Access
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

Calling workflows using `uses:` cannot have `environment:` set on the calling job. This means `${{ secrets.AWS_ROLE_ARN }}` resolves to empty when `AWS_ROLE_ARN` is an environment secret. The called workflow declared it `required: true`, causing a `startup_failure` before any steps ran.

## Fix

- Removes `secrets: AWS_ROLE_ARN` from `workflow_call` inputs
- Adds `environment` string input (default: `production`)
- Sets `environment: ${{ inputs.environment }}` on the job — this makes the reusable workflow's job access `secrets.AWS_ROLE_ARN` directly from the calling repo's named environment

## Callers

No changes needed in calling workflows — the `secrets:` section can be dropped entirely:

```yaml
jobs:
  access-analyzer:
    uses: Specter099/.github/.github/workflows/access-analyzer-check.yml@main
    with:
      yaml-template-dir: .
      # environment: production  # optional, defaults to "production"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)