### PR TITLE
feat: add bandit and checkov security scans to CI

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -1,6 +1,7 @@
+---
 name: CDK Review
 
-on:
+"on":
   workflow_call:
     inputs:
       aws-region:
@@ -17,7 +18,9 @@ on:
         default: ""
     secrets:
       AWS_ROLE_ARN:
-        description: IAM role ARN for OIDC federation (optional — skips synth/diff if absent)
+        description: >-
+          IAM role ARN for OIDC federation
+          (optional — skips synth/diff if absent)
         required: false
 jobs:
   gitleaks:
@@ -87,9 +90,22 @@ jobs:
         if: secrets.AWS_ROLE_ARN != ''
         run: cdk synth
 
+      - name: SAST scan (bandit)
+        run: |
+          pip install bandit
+          bandit -r . -ll --exclude .venv,cdk.out
+
+      - name: IaC scan (checkov)
+        run: |
+          pip install checkov
+          checkov -d cdk.out --framework cloudformation \
+            --quiet --compact
+
       - name: CDK Nag (informational)
         if: secrets.AWS_ROLE_ARN != ''
-        run: CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" || true
+        run: >-
+          CDK_NAG=true cdk synth 2>&1
+          | grep -E "^\[.*Nag\]|AwsSolutions" || true
 
       - name: CDK Diff
         if: secrets.AWS_ROLE_ARN != ''

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,16 +1,21 @@
+---
 name: Python CI
 # Requires callers to include ruff and pytest in their requirements file.
 # Install via requirements-path (default) or override with install-command.
 
-on:
+"on":
   workflow_call:
     inputs:
       python-versions:
-        description: JSON array of Python versions for matrix (e.g. '["3.11","3.12"]')
+        description: >-
+          JSON array of Python versions for matrix
+          (e.g. '["3.11","3.12"]')
         type: string
         default: '["3.12"]'
       requirements-path:
-        description: Path to dev requirements file (ignored if install-command is set)
+        description: >-
+          Path to dev requirements file
+          (ignored if install-command is set)
         type: string
         default: "requirements-dev.txt"
       install-command:
@@ -26,11 +31,17 @@ on:
         type: boolean
         default: false
       coverage-threshold:
-        description: Minimum coverage percentage (only used when coverage is true)
+        description: >-
+          Minimum coverage percentage
+          (only used when coverage is true)
         type: number
         default: 80
       pip-audit:
         description: Run pip-audit dependency vulnerability scan
+        type: boolean
+        default: false
+      bandit:
+        description: Run bandit SAST scan (medium+ severity)
         type: boolean
         default: false
 
@@ -82,6 +93,12 @@ jobs:
           pip install pip-audit
           pip-audit
 
+      - name: SAST scan (bandit)
+        if: ${{ inputs.bandit }}
+        run: |
+          pip install bandit
+          bandit -r . -ll --exclude .venv,cdk.out
+
       - name: Unit tests (pytest)
         if: ${{ !inputs.coverage }}
         run: pytest ${{ inputs.tests-dir }} -v
@@ -90,4 +107,7 @@ jobs:
         if: ${{ inputs.coverage }}
         run: |
           pip install pytest-cov
-          pytest ${{ inputs.tests-dir }} -v --cov --cov-report=term-missing --cov-fail-under=${{ inputs.coverage-threshold }}
+          pytest ${{ inputs.tests-dir }} -v \
+            --cov \
+            --cov-report=term-missing \
+            --cov-fail-under=${{ inputs.coverage-threshold }}


### PR DESCRIPTION
## Summary
- Adds optional `bandit` input to `python-ci.yml` for Python SAST scanning (medium+ severity, default `false`)
- Adds always-on bandit + checkov steps to `cdk-review.yml` — bandit scans Python source, checkov scans `cdk.out/` using the CloudFormation framework after `cdk synth`

## Test plan
- [ ] Trigger a CDK repo PR and verify bandit and checkov steps appear in the `cdk-review` job
- [ ] Enable `bandit: true` in a caller of `python-ci` and verify the step runs
- [ ] Confirm checkov flags a real misconfiguration (e.g. unencrypted bucket) in `cdk.out`
- [ ] Confirm bandit exits 0 on clean Python code and non-zero on a medium+ finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)