### PR TITLE
feat: add access-analyzer composite action for CDK repos

### DIFF
--- a/.github/actions/access-analyzer/action.yml
+++ b/.github/actions/access-analyzer/action.yml
@@ -1,0 +1,181 @@
+name: IAM Access Analyzer — Check No Public Access
+description: >
+  Scans synthesized CloudFormation templates in cdk.out using AWS IAM Access Analyzer
+  checkNoPublicAccess API. AWS credentials must be configured before calling this action.
+
+inputs:
+  template-dir:
+    description: Directory containing CloudFormation *.template.json files
+    default: cdk.out
+  yaml-template-dir:
+    description: >
+      Directory containing CloudFormation *.yaml/*.yml templates to convert and scan.
+      Leave empty to skip.
+    default: ""
+  fail-on-public-access:
+    description: Fail when public access is detected (set 'false' for warn-only)
+    default: "true"
+  aws-region:
+    description: AWS region for Access Analyzer API calls
+    default: us-east-1
+
+runs:
+  using: composite
+  steps:
+    - name: Install access analyzer dependencies
+      shell: bash
+      run: pip install --quiet --upgrade boto3 cfn-flip
+
+    - name: Convert CloudFormation YAML templates to JSON
+      if: inputs.yaml-template-dir != ''
+      shell: bash
+      env:
+        YAML_DIR: ${{ inputs.yaml-template-dir }}
+      run: |
+        mkdir -p cfn-yaml-out
+        find "$YAML_DIR" -maxdepth 1 \( -name "*.yaml" -o -name "*.yml" \) | while read -r f; do
+          out="cfn-yaml-out/$(basename "${f%.*}").template.json"
+          cfn-flip "$f" "$out" && echo "Converted: $f -> $out"
+        done
+
+    - name: Check no public access
+      shell: bash
+      env:
+        TEMPLATE_DIR: ${{ inputs.template-dir }}
+        YAML_TEMPLATE_DIR: ${{ inputs.yaml-template-dir != '' && 'cfn-yaml-out' || '' }}
+        FAIL_ON_PUBLIC_ACCESS: ${{ inputs.fail-on-public-access }}
+        AWS_REGION: ${{ inputs.aws-region }}
+      run: |
+        python3 << 'PYEOF'
+        import json
+        import os
+        import sys
+        from pathlib import Path
+
+        import boto3
+        from botocore.exceptions import ClientError
+
+        POLICY_MAP = {
+            "AWS::S3::BucketPolicy":               ("PolicyDocument",           "AWS::S3::Bucket"),
+            "AWS::SQS::QueuePolicy":               ("PolicyDocument",           "AWS::SQS::Queue"),
+            "AWS::SNS::TopicPolicy":               ("PolicyDocument",           "AWS::SNS::Topic"),
+            "AWS::KMS::Key":                       ("KeyPolicy",                "AWS::KMS::Key"),
+            "AWS::ECR::Repository":                ("RepositoryPolicyText",     "AWS::ECR::Repository"),
+            "AWS::SecretsManager::ResourcePolicy": ("ResourcePolicy",           "AWS::SecretsManager::Secret"),
+            "AWS::IAM::Role":                      ("AssumeRolePolicyDocument", "AWS::IAM::AssumeRolePolicyDocument"),
+        }
+
+        template_dir      = Path(os.environ["TEMPLATE_DIR"])
+        yaml_template_dir = os.environ.get("YAML_TEMPLATE_DIR", "")
+        fail_on_public    = os.environ["FAIL_ON_PUBLIC_ACCESS"].lower() == "true"
+        aws_region        = os.environ.get("AWS_REGION", "us-east-1")
+        summary_path      = os.environ.get("GITHUB_STEP_SUMMARY")
+
+        def find_templates(d):
+            skip = {"manifest.json", "tree.json"}
+            return sorted(
+                p for p in d.rglob("*.template.json")
+                if p.name not in skip and not p.name.startswith("asset.")
+            )
+
+        def extract_policies(template):
+            results = []
+            for lid, res in template.get("Resources", {}).items():
+                cf_type = res.get("Type", "")
+                if cf_type not in POLICY_MAP:
+                    continue
+                policy_prop, analyzer_type = POLICY_MAP[cf_type]
+                policy_doc = res.get("Properties", {}).get(policy_prop)
+                if policy_doc is not None:
+                    results.append((lid, analyzer_type, policy_doc))
+            return results
+
+        def check_policy(client, lid, analyzer_type, policy_doc):
+            try:
+                resp = client.check_no_public_access(
+                    policyDocument=json.dumps(policy_doc),
+                    resourceType=analyzer_type,
+                )
+                is_public = resp.get("result") == "FAIL"
+                reasons   = [r.get("description", "") for r in resp.get("reasons", [])]
+                return {"logical_id": lid, "resource_type": analyzer_type,
+                        "public": is_public, "reasons": reasons}
+            except ClientError as exc:
+                code = exc.response["Error"]["Code"]
+                msg  = exc.response["Error"]["Message"]
+                return {"logical_id": lid, "resource_type": analyzer_type,
+                        "public": False, "error": f"{code}: {msg}"}
+
+        def append_summary(findings, template_name):
+            if not summary_path:
+                return
+            with open(summary_path, "a") as f:
+                f.write(f"\n### Access Analyzer - `{template_name}`\n\n")
+                if not findings:
+                    f.write("_No applicable resources found._\n")
+                    return
+                f.write("| Resource | Type | Result |\n|---|---|---|\n")
+                for r in findings:
+                    if "error" in r:
+                        icon, status = "warning", f"Error: {r['error']}"
+                    elif r["public"]:
+                        reasons = "; ".join(r["reasons"]) if r["reasons"] else "public access detected"
+                        icon, status = "x", f"FAIL - {reasons}"
+                    else:
+                        icon, status = "check", "PASS"
+                    f.write(f"| `{r['logical_id']}` | `{r['resource_type']}` | :{icon}: {status} |\n")
+
+        def scan_dir(client, d, total_violations):
+            if not d.is_dir():
+                return total_violations
+            templates = find_templates(d)
+            if not templates:
+                print(f"::notice::No *.template.json files found in '{d}' - skipping")
+                return total_violations
+            for tpl_path in templates:
+                name = tpl_path.name
+                print(f"\n=== {name} ===")
+                try:
+                    template = json.loads(tpl_path.read_text())
+                except json.JSONDecodeError as exc:
+                    print(f"::warning::Could not parse {name}: {exc}")
+                    continue
+                policies = extract_policies(template)
+                if not policies:
+                    print("  No applicable resources found - skipping")
+                    append_summary([], name)
+                    continue
+                findings = []
+                for lid, analyzer_type, policy_doc in policies:
+                    result = check_policy(client, lid, analyzer_type, policy_doc)
+                    findings.append(result)
+                    if "error" in result:
+                        print(f"  [!] {lid} ({analyzer_type}) - error: {result['error']}")
+                    elif result["public"]:
+                        total_violations += 1
+                        reasons = "; ".join(result["reasons"]) if result["reasons"] else "public access detected"
+                        print(f"  [x] {lid} ({analyzer_type}) - FAIL: {reasons}")
+                    else:
+                        print(f"  [ok] {lid} ({analyzer_type}) - PASS")
+                append_summary(findings, name)
+            return total_violations
+
+        client           = boto3.client("accessanalyzer", region_name=aws_region)
+        total_violations = 0
+
+        total_violations = scan_dir(client, template_dir, total_violations)
+        if yaml_template_dir:
+            total_violations = scan_dir(client, Path(yaml_template_dir), total_violations)
+
+        print()
+        if total_violations > 0:
+            print(f"::error::{total_violations} resource(s) grant public access")
+            sys.exit(1 if fail_on_public else 0)
+        else:
+            print("All resources passed the no-public-access check.")
+        PYEOF
+
+    - name: Notify on public access detected
+      if: failure()
+      shell: bash
+      run: echo "::error::IAM Access Analyzer detected resources that grant public access. Review the job output for details."

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+---
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  truthy:
+    allowed-values: ["true", "false", "on"]


### PR DESCRIPTION
## Summary
- Extracts IAM Access Analyzer scan logic into a composite action
- CDK repos call this as a step after `cdk synth`, avoiding artifact-passing between jobs
- AWS credentials must be configured by the caller before using this action
- Single source of truth — logic no longer duplicated across repos

## Usage in CDK repos
```yaml
- uses: Specter099/.github/.github/actions/access-analyzer@main
  with:
    template-dir: cdk.out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)