### PR TITLE
fix: install requirements.txt in cdk-review workflow

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -45,8 +45,10 @@ jobs:
         with:
           cdk-version: ${{ inputs.cdk-version }}
 
-      - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
 
       - name: Lint (ruff)
         if: hashFiles('requirements-dev.txt') != '' && success()


### PR DESCRIPTION
## Summary
- Installs `requirements.txt` (which contains `aws-cdk-lib`) before `requirements-dev.txt`
- Fixes `ModuleNotFoundError: No module named 'aws_cdk'` when `cdk synth` runs in repos where CDK packages live in `requirements.txt` and dev tools in `requirements-dev.txt` (the standard CDK Python project layout)
- Uses `[ -f requirements-dev.txt ] && ...` guard so repos without a dev file still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)