### PR TITLE
fix: deploy --all stacks and accept role ARN as variable or secret

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -11,6 +11,10 @@ on:
         description: CDK CLI npm version to install
         type: string
         default: "2.1106.1"
+      stacks:
+        description: Stack name(s) to deploy, or '--all' for all stacks
+        type: string
+        default: "--all"
       smoke-test-url:
         description: URL to curl after deploy for smoke test (optional)
         type: string
@@ -34,11 +38,13 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: CDK Deploy
-        run: cdk deploy --require-approval never --outputs-file outputs.json
+        env:
+          CDK_STACKS: ${{ inputs.stacks }}
+        run: cdk deploy $CDK_STACKS --require-approval never --outputs-file outputs.json
 
       - name: Upload stack outputs
         if: always()


### PR DESCRIPTION
## Problems

Two regressions introduced by the CI/CD workflow migration:

### 1. Multi-stack apps fail on `cdk deploy`
CDK requires `--all` (or explicit stack names) when an app has more than one stack. Without it:
\`\`\`
Since this app includes more than a single stack, specify which stacks to use or specify --all
Stacks: Route53Stack · KnitNStitchStack
\`\`\`
Affected: route53-cdk (2 stacks), and potentially others.

### 2. \`AWS_ROLE_ARN\` stored as variable, not secret
Some repos (e.g. route53-cdk) stored \`AWS_ROLE_ARN\` as a repository **variable** (\`vars.AWS_ROLE_ARN\`) under the old workflow. The reusable workflow used \`secrets.AWS_ROLE_ARN\`, which resolves to empty → OIDC auth fails silently.

## Fixes

- Add `stacks` input (default: `--all`) — callers can override with specific stack names
- Fall back to `vars.AWS_ROLE_ARN` if `secrets.AWS_ROLE_ARN` is unset — both conventions work

## After merge

Re-run the failed CD jobs in route53-cdk, workspaces-secure-browser-cdk, and ai-powered-network-operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)