### PR TITLE
fix: remove AWS::IAM::Role from Access Analyzer policy map

### DIFF
--- a/.github/actions/access-analyzer/action.yml
+++ b/.github/actions/access-analyzer/action.yml
@@ -62,7 +62,9 @@ runs:
             "AWS::KMS::Key":                       ("KeyPolicy",                "AWS::KMS::Key"),
             "AWS::ECR::Repository":                ("RepositoryPolicyText",     "AWS::ECR::Repository"),
             "AWS::SecretsManager::ResourcePolicy": ("ResourcePolicy",           "AWS::SecretsManager::Secret"),
-            "AWS::IAM::Role":                      ("AssumeRolePolicyDocument", "AWS::IAM::AssumeRolePolicyDocument"),
+            # AWS::IAM::Role excluded: CDK trust policies contain intrinsic functions
+            # (Fn::Sub, Ref, Fn::If) that CheckNoPublicAccess cannot evaluate, producing
+            # misleading errors. OIDC trust policies also trigger false positives.
         }
 
         template_dir      = Path(os.environ["TEMPLATE_DIR"])

--- a/.github/workflows/access-analyzer-check.yml
+++ b/.github/workflows/access-analyzer-check.yml
@@ -92,7 +92,9 @@ jobs:
               "AWS::KMS::Key":                       ("KeyPolicy",                "AWS::KMS::Key"),
               "AWS::ECR::Repository":                ("RepositoryPolicyText",     "AWS::ECR::Repository"),
               "AWS::SecretsManager::ResourcePolicy": ("ResourcePolicy",           "AWS::SecretsManager::Secret"),
-              "AWS::IAM::Role":                      ("AssumeRolePolicyDocument", "AWS::IAM::AssumeRolePolicyDocument"),
+              # AWS::IAM::Role excluded: CDK trust policies contain intrinsic functions
+            # (Fn::Sub, Ref, Fn::If) that CheckNoPublicAccess cannot evaluate, producing
+            # misleading errors. OIDC trust policies also trigger false positives.
           }
 
           template_dir      = Path(os.environ["TEMPLATE_DIR"])


### PR DESCRIPTION
## Problem

The Access Analyzer scan was including `AWS::IAM::Role` trust policies in its `CheckNoPublicAccess` checks. This caused two issues:

1. **Misleading API errors** — CDK-generated trust policies contain CloudFormation intrinsic functions (`Fn::Sub`, `Ref`, `Fn::If`) that the API cannot evaluate. The result was `ClientError` exceptions shown as `:warning:` in the job summary — appearing to flag something, but not actually failing the job.

2. **False positives on OIDC roles** — Even with a fully-resolved policy, OIDC trust policies with a federated principal (like `github-actions-role`) can be flagged as "public" because Access Analyzer sees the federated principal as broad, even when a `StringLike` condition properly restricts which repos can assume the role.

## Fix

Removed `AWS::IAM::Role` from `POLICY_MAP` in both the composite action and the reusable workflow. IAM trust policy review is better suited to dedicated IAM analysis tooling — `CheckNoPublicAccess` is designed for data-plane resource policies (S3, SQS, KMS) that can expose data to the internet.

## Files Changed

- `.github/actions/access-analyzer/action.yml`
- `.github/workflows/access-analyzer-check.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)