### PR TITLE
feat: add environment input to cdk-deploy reusable workflow

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -15,6 +15,10 @@ on:
         description: Stack name(s) to deploy, or '--all' for all stacks
         type: string
         default: "--all"
+      environment:
+        description: GitHub environment to use (controls which secrets/vars are loaded)
+        type: string
+        default: "production"
       smoke-test-url:
         description: URL to curl after deploy for smoke test (optional)
         type: string
@@ -26,7 +30,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    environment: production
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +54,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: stack-outputs
+          name: stack-outputs-${{ inputs.environment }}
           path: outputs.json
           if-no-files-found: ignore
 


### PR DESCRIPTION
## Summary
- Add `environment` input (default: `"production"`) so callers can target different GitHub environments with different AWS role ARNs
- Suffix artifact name with environment to prevent collisions when a workflow calls this reusable workflow multiple times

## Motivation
`route53-cdk` deploys two stacks to two different AWS accounts. Each account has its own GitHub Actions role. By parameterizing the environment, each deploy job can use the correct role without changes to the reusable workflow's credential logic.

## Backward compatible
Existing callers that don't pass `environment` continue using `production` — no changes needed.

## Test plan
- [ ] Existing callers (static-site-infra, route53-cdk single-stack) still work
- [ ] route53-cdk multi-account deploy works with `environment: knit-n-stitch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)