### PR TITLE
fix: default backup environment from production to backup

### DIFF
--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -18,7 +18,7 @@ on:
       environment:
         description: GitHub environment whose secrets contain AWS_ROLE_ARN
         type: string
-        default: "production"
+        default: "backup"
   workflow_dispatch:
     inputs:
       s3-bucket:
@@ -36,7 +36,7 @@ on:
       environment:
         description: GitHub environment whose secrets contain AWS_ROLE_ARN
         type: string
-        default: "production"
+        default: "backup"
 
 jobs:
   backup:


### PR DESCRIPTION
## Summary
Change the default `environment` input in the reusable `repo-backup.yml` from `"production"` to `"backup"`.

## Context
All 27+ repos with backup workflows now have a `backup` environment with `AWS_ROLE_ARN` pointing to `arn:aws:iam::451645558365:role/github-actions-role` (the account where the central backup bucket lives). This cleanly separates deploy and backup credentials, fixing cross-account S3 write failures for repos that deploy to different accounts.

## Impact
- Repos using the reusable workflow without passing `environment` will now use `backup` instead of `production`
- All repos have the `backup` environment created with the correct secret
- No caller changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)