### PR TITLE
fix: remove nested gitleaks call from cdk-review

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -23,13 +23,6 @@ name: CDK Review
           (optional — skips synth/diff if absent)
         required: false
 jobs:
-  gitleaks:
-    name: Secret Scan
-    uses: Specter099/.github/.github/workflows/gitleaks.yml@main
-    permissions:
-      contents: read
-      pull-requests: read
-
   review:
     name: Synth & Diff
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove the `gitleaks` job from `cdk-review.yml` that calls `gitleaks.yml` as a nested reusable workflow
- Nested reusable workflows (a reusable workflow calling another reusable workflow) cause `startup_failure` in caller repos due to GitHub Actions limitations
- Callers should add gitleaks as a separate top-level job in their own `pr.yml` instead

## Changes
- `.github/workflows/cdk-review.yml`: removed the `gitleaks` job block (lines 26-31). The `review` job is unchanged.

## Test plan
- [ ] Verify a caller repo's PR workflow no longer hits `startup_failure`
- [ ] Verify caller repos add `gitleaks` as a separate job in their own `pr.yml`

Generated with [Claude Code](https://claude.ai/code)