### PR TITLE
chore: remove checkov from CDK review workflow

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -99,12 +99,6 @@ jobs:
           pip install bandit
           bandit -r . -ll --exclude .venv,cdk.out
 
-      - name: IaC scan (checkov)
-        run: |
-          pip install checkov
-          checkov -d cdk.out --framework cloudformation \
-            --quiet --compact
-
       - name: CDK Nag (informational)
         if: env.AWS_ROLE_ARN != ''
         run: >-


### PR DESCRIPTION
## Summary
- Removes the checkov IaC scan step from the reusable CDK review workflow
- Checkov consistently flags intentional design choices, adding CI noise without actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)