### PR TITLE
feat: add opt-in CI/CD log shipping to S3 and CloudWatch

### DIFF
--- a/.github/actions/ship-logs/action.yml
+++ b/.github/actions/ship-logs/action.yml
@@ -1,0 +1,164 @@
+name: Ship CI/CD Logs
+description: >
+  Upload workflow step logs to S3 and/or CloudWatch Logs.
+  AWS credentials must be configured before calling this action.
+
+inputs:
+  log-dir:
+    description: Directory containing *.log files and metadata.json
+    required: true
+  destination:
+    description: "Where to send logs: s3, cloudwatch, or both"
+    required: false
+    default: "s3"
+  s3-bucket:
+    description: S3 bucket name (required when destination includes s3)
+    required: false
+    default: ""
+  s3-prefix:
+    description: S3 key prefix inside the bucket
+    required: false
+    default: "ci-logs"
+  cloudwatch-log-group:
+    description: CloudWatch Logs log group name
+    required: false
+    default: "/github-actions/ci-cd"
+  aws-region:
+    description: AWS region
+    required: false
+    default: "us-east-1"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve log path variables
+      id: vars
+      shell: bash
+      run: |
+        REPO="${{ github.repository }}"
+        WORKFLOW="${{ github.workflow }}"
+        RUN_ID="${{ github.run_id }}"
+        ATTEMPT="${{ github.run_attempt }}"
+        # Sanitise workflow name for use as a path segment
+        SAFE_WORKFLOW=$(echo "$WORKFLOW" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
+        S3_KEY="${{ inputs.s3-prefix }}/${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}"
+        CW_STREAM="${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}"
+        echo "s3-key=${S3_KEY}" >> "$GITHUB_OUTPUT"
+        echo "cw-stream=${CW_STREAM}" >> "$GITHUB_OUTPUT"
+
+    - name: Upload logs to S3
+      if: contains(inputs.destination, 's3') && inputs.s3-bucket != ''
+      shell: bash
+      env:
+        LOG_DIR: ${{ inputs.log-dir }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_KEY: ${{ steps.vars.outputs.s3-key }}
+      run: |
+        set -euo pipefail
+        # Bundle all logs into a tarball
+        tar czf "${RUNNER_TEMP}/ci-logs.tar.gz" -C "$LOG_DIR" .
+        # Upload tarball
+        aws s3 cp "${RUNNER_TEMP}/ci-logs.tar.gz" \
+          "s3://${S3_BUCKET}/${S3_KEY}/logs.tar.gz"
+        # Upload metadata separately for easy querying
+        if [ -f "${LOG_DIR}/metadata.json" ]; then
+          aws s3 cp "${LOG_DIR}/metadata.json" \
+            "s3://${S3_BUCKET}/${S3_KEY}/metadata.json"
+        fi
+        S3_URI="s3://${S3_BUCKET}/${S3_KEY}/"
+        echo "## CI Logs — S3" >> "$GITHUB_STEP_SUMMARY"
+        echo "Logs uploaded to \`${S3_URI}\`" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Send logs to CloudWatch
+      if: contains(inputs.destination, 'cloudwatch')
+      shell: bash
+      env:
+        LOG_DIR: ${{ inputs.log-dir }}
+        LOG_GROUP: ${{ inputs.cloudwatch-log-group }}
+        LOG_STREAM: ${{ steps.vars.outputs.cw-stream }}
+        AWS_REGION: ${{ inputs.aws-region }}
+      run: |
+        set -euo pipefail
+        # Create log group (ignore if exists) with 90-day retention
+        aws logs create-log-group \
+          --log-group-name "$LOG_GROUP" \
+          --region "$AWS_REGION" 2>/dev/null || true
+        aws logs put-retention-policy \
+          --log-group-name "$LOG_GROUP" \
+          --retention-in-days 90 \
+          --region "$AWS_REGION" 2>/dev/null || true
+        # Create log stream
+        aws logs create-log-stream \
+          --log-group-name "$LOG_GROUP" \
+          --log-stream-name "$LOG_STREAM" \
+          --region "$AWS_REGION"
+        # Send each log file as a batch of events
+        SEQUENCE_TOKEN=""
+        for logfile in "$LOG_DIR"/*.log; do
+          [ -f "$logfile" ] || continue
+          BASENAME=$(basename "$logfile")
+          # Build JSON log events array — one event per line, prefixed with filename
+          EVENTS="[]"
+          TS_MS=$(date +%s%3N)
+          while IFS= read -r line || [ -n "$line" ]; do
+            # Escape the line for JSON
+            ESCAPED=$(printf '%s' "$line" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()), end="")')
+            EVENTS=$(echo "$EVENTS" | python3 -c "
+        import json, sys
+        events = json.load(sys.stdin)
+        events.append({'timestamp': $TS_MS, 'message': '[${BASENAME}] ' + json.loads($ESCAPED)})
+        print(json.dumps(events))
+        ")
+            TS_MS=$((TS_MS + 1))
+          done < "$logfile"
+          # Skip empty files
+          EVENT_COUNT=$(echo "$EVENTS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+          [ "$EVENT_COUNT" -eq 0 ] && continue
+          # put-log-events (max 1MB / 10000 events per call — CI logs are well under)
+          if [ -z "$SEQUENCE_TOKEN" ]; then
+            RESULT=$(aws logs put-log-events \
+              --log-group-name "$LOG_GROUP" \
+              --log-stream-name "$LOG_STREAM" \
+              --log-events "$EVENTS" \
+              --region "$AWS_REGION" 2>&1) || true
+          else
+            RESULT=$(aws logs put-log-events \
+              --log-group-name "$LOG_GROUP" \
+              --log-stream-name "$LOG_STREAM" \
+              --log-events "$EVENTS" \
+              --sequence-token "$SEQUENCE_TOKEN" \
+              --region "$AWS_REGION" 2>&1) || true
+          fi
+          # Extract next sequence token for subsequent puts
+          SEQUENCE_TOKEN=$(echo "$RESULT" | python3 -c "
+        import json, sys
+        try:
+            print(json.loads(sys.stdin.read()).get('nextSequenceToken',''))
+        except Exception:
+            print('')
+        " 2>/dev/null) || true
+        done
+        # Also send metadata.json as a single event
+        if [ -f "${LOG_DIR}/metadata.json" ]; then
+          META=$(cat "${LOG_DIR}/metadata.json")
+          META_ESCAPED=$(printf '%s' "$META" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()), end="")')
+          META_TS=$(date +%s%3N)
+          META_EVENTS="[{\"timestamp\": ${META_TS}, \"message\": $(echo "$META_ESCAPED")}]"
+          if [ -z "$SEQUENCE_TOKEN" ]; then
+            aws logs put-log-events \
+              --log-group-name "$LOG_GROUP" \
+              --log-stream-name "$LOG_STREAM" \
+              --log-events "$META_EVENTS" \
+              --region "$AWS_REGION" 2>/dev/null || true
+          else
+            aws logs put-log-events \
+              --log-group-name "$LOG_GROUP" \
+              --log-stream-name "$LOG_STREAM" \
+              --log-events "$META_EVENTS" \
+              --sequence-token "$SEQUENCE_TOKEN" \
+              --region "$AWS_REGION" 2>/dev/null || true
+          fi
+        fi
+        echo "## CI Logs — CloudWatch" >> "$GITHUB_STEP_SUMMARY"
+        echo "Log group: \`${LOG_GROUP}\`  " >> "$GITHUB_STEP_SUMMARY"
+        echo "Log stream: \`${LOG_STREAM}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -23,6 +23,22 @@ on:
         description: URL to curl after deploy for smoke test (optional)
         type: string
         default: ""
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: false
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "s3"
+      ci-log-s3-bucket:
+        description: S3 bucket for CI logs
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: CloudWatch Logs group name
+        type: string
+        default: "/github-actions/ci-cd"
 jobs:
   deploy:
     name: Deploy
@@ -33,6 +49,10 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
 
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
@@ -48,7 +68,14 @@ jobs:
       - name: CDK Deploy
         env:
           CDK_STACKS: ${{ inputs.stacks }}
-        run: cdk deploy $CDK_STACKS --require-approval never --outputs-file outputs.json
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            cdk deploy $CDK_STACKS --require-approval never --outputs-file outputs.json 2>&1 | tee "$RUNNER_TEMP/ci-logs/cdk-deploy.log"
+          else
+            cdk deploy $CDK_STACKS --require-approval never --outputs-file outputs.json
+          fi
 
       - name: Upload stack outputs
         if: always()
@@ -72,14 +99,53 @@ jobs:
 
       - name: Smoke test
         if: ${{ inputs.smoke-test-url != '' }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
-          status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
-            "${{ inputs.smoke-test-url }}" || echo "000")
-          echo "Smoke test HTTP status: $status"
-          echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
-          echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "$status" == "000" ]]; then
-            echo "::warning::Smoke test: curl failed or timed out"
+          set -o pipefail
+          _run_smoke() {
+            status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
+              "${{ inputs.smoke-test-url }}" || echo "000")
+            echo "Smoke test HTTP status: $status"
+            echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
+            echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
+            if [[ "$status" == "000" ]]; then
+              echo "::warning::Smoke test: curl failed or timed out"
+            else
+              echo "Smoke test passed — endpoint is reachable."
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_smoke 2>&1 | tee "$RUNNER_TEMP/ci-logs/smoke-test.log"
           else
-            echo "Smoke test passed — endpoint is reachable."
+            _run_smoke
           fi
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        run: |
+          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
+          {
+            "repository": "${{ github.repository }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "actor": "${{ github.actor }}",
+            "event": "${{ github.event_name }}",
+            "job_status": "${{ job.status }}",
+            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          }
+          METAEOF
+          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -16,6 +16,22 @@ name: CDK Review
         description: URL to curl after deploy (optional)
         type: string
         default: ""
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: false
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "s3"
+      ci-log-s3-bucket:
+        description: S3 bucket for CI logs
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: CloudWatch Logs group name
+        type: string
+        default: "/github-actions/ci-cd"
     secrets:
       AWS_ROLE_ARN:
         description: >-
@@ -35,6 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
+
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
@@ -47,33 +67,63 @@ jobs:
 
       - name: Lint (ruff)
         if: hashFiles('requirements-dev.txt') != '' && success()
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
-          if command -v ruff &> /dev/null; then
-            ruff check .
+          set -o pipefail
+          _run_lint() {
+            if command -v ruff &> /dev/null; then
+              ruff check .
+            else
+              echo "::notice::ruff not installed — skipping lint"
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_lint 2>&1 | tee "$RUNNER_TEMP/ci-logs/ruff-check.log"
           else
-            echo "::notice::ruff not installed — skipping lint"
+            _run_lint
           fi
 
       - name: Unit tests
         if: hashFiles('tests/') != '' && success()
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
-          if command -v pytest &> /dev/null; then
-            pytest tests/ -v || rc=$?
-            if [ "${rc:-0}" -eq 5 ]; then
-              echo "::notice::no tests collected — skipping"
-            elif [ "${rc:-0}" -ne 0 ]; then
-              exit "$rc"
+          set -o pipefail
+          _run_tests() {
+            if command -v pytest &> /dev/null; then
+              pytest tests/ -v || rc=$?
+              if [ "${rc:-0}" -eq 5 ]; then
+                echo "::notice::no tests collected — skipping"
+              elif [ "${rc:-0}" -ne 0 ]; then
+                exit "$rc"
+              fi
+            else
+              echo "::notice::pytest not installed — skipping tests"
             fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_tests 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest.log"
           else
-            echo "::notice::pytest not installed — skipping tests"
+            _run_tests
           fi
 
       - name: Dependency audit
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
-          if command -v pip-audit &> /dev/null; then
-            pip-audit -r requirements.txt
+          set -o pipefail
+          _run_audit() {
+            if command -v pip-audit &> /dev/null; then
+              pip-audit -r requirements.txt
+            else
+              echo "::notice::pip-audit not installed — skipping audit"
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_audit 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
           else
-            echo "::notice::pip-audit not installed — skipping audit"
+            _run_audit
           fi
 
       - name: Configure AWS credentials
@@ -85,22 +135,45 @@ jobs:
 
       - name: CDK Synth
         if: env.AWS_ROLE_ARN != ''
-        run: cdk synth
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            cdk synth 2>&1 | tee "$RUNNER_TEMP/ci-logs/cdk-synth.log"
+          else
+            cdk synth
+          fi
 
       - name: SAST scan (bandit)
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
+          set -o pipefail
           pip install bandit
-          bandit -r . -ll --exclude .venv,cdk.out
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            bandit -r . -ll --exclude .venv,cdk.out 2>&1 | tee "$RUNNER_TEMP/ci-logs/bandit.log"
+          else
+            bandit -r . -ll --exclude .venv,cdk.out
+          fi
 
       - name: CDK Nag (informational)
         if: env.AWS_ROLE_ARN != ''
-        run: >-
-          CDK_NAG=true cdk synth 2>&1
-          | grep -E "^\[.*Nag\]|AwsSolutions" || true
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" | tee "$RUNNER_TEMP/ci-logs/cdk-nag.log" || true
+          else
+            CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" || true
+          fi
 
       - name: CDK Diff
         if: env.AWS_ROLE_ARN != ''
         id: diff
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           diff_output=$(cdk diff 2>&1) || true
           echo "$diff_output"
@@ -109,6 +182,9 @@ jobs:
             echo "$diff_output"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            echo "$diff_output" > "$RUNNER_TEMP/ci-logs/cdk-diff.log"
+          fi
 
       - name: Comment diff on PR
         if: env.AWS_ROLE_ARN != ''
@@ -146,3 +222,32 @@ jobs:
       - name: AWS credentials not configured
         if: env.AWS_ROLE_ARN == ''
         run: echo "::warning::AWS_ROLE_ARN secret not set — skipping synth/diff"
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        run: |
+          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
+          {
+            "repository": "${{ github.repository }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "actor": "${{ github.actor }}",
+            "event": "${{ github.event_name }}",
+            "job_status": "${{ job.status }}",
+            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          }
+          METAEOF
+          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -49,12 +49,38 @@ name: Python CI
         description: Run bandit SAST scan (medium+ severity)
         type: boolean
         default: false
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: false
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "s3"
+      ci-log-s3-bucket:
+        description: S3 bucket for CI logs
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: CloudWatch Logs group name
+        type: string
+        default: "/github-actions/ci-cd"
+      aws-region:
+        description: AWS region (used for CI log shipping)
+        type: string
+        default: "us-east-1"
+    secrets:
+      AWS_ROLE_ARN:
+        description: >-
+          IAM role ARN for OIDC federation (required when enable-ci-logs is true)
+        required: false
 
 jobs:
   ci:
     name: "Lint, Secrets & Test (py${{ matrix.python-version }})"
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     strategy:
       fail-fast: false
@@ -65,6 +91,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0  # full history required by gitleaks
+
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -87,10 +117,26 @@ jobs:
           fi
 
       - name: Lint (ruff)
-        run: ruff check .
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            ruff check . 2>&1 | tee "$RUNNER_TEMP/ci-logs/ruff-check.log"
+          else
+            ruff check .
+          fi
 
       - name: Format check (ruff)
-        run: ruff format --check .
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            ruff format --check . 2>&1 | tee "$RUNNER_TEMP/ci-logs/ruff-format.log"
+          else
+            ruff format --check .
+          fi
 
       - name: Secrets scan (gitleaks)
         uses: gitleaks/gitleaks-action@f586c14365d4643c6aa59d472ae6e984bf47bb34  # v2.3.8
@@ -99,30 +145,96 @@ jobs:
 
       - name: Dependency audit (pip-audit)
         if: ${{ inputs.pip-audit }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
+          set -o pipefail
           pip install pip-audit
-          pip-audit
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pip-audit 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
+          else
+            pip-audit
+          fi
 
       - name: SAST scan (bandit)
         if: ${{ inputs.bandit }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
+          set -o pipefail
           pip install bandit
-          bandit -r . -ll --exclude .venv,cdk.out
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            bandit -r . -ll --exclude .venv,cdk.out 2>&1 | tee "$RUNNER_TEMP/ci-logs/bandit.log"
+          else
+            bandit -r . -ll --exclude .venv,cdk.out
+          fi
 
       - name: Unit tests (pytest)
         if: ${{ !inputs.coverage }}
         env:
           TESTS_DIR: ${{ inputs.tests-dir }}
-        run: pytest "$TESTS_DIR" -v
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pytest "$TESTS_DIR" -v 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest.log"
+          else
+            pytest "$TESTS_DIR" -v
+          fi
 
       - name: Unit tests with coverage (pytest-cov)
         if: ${{ inputs.coverage }}
         env:
           TESTS_DIR: ${{ inputs.tests-dir }}
           COV_THRESHOLD: ${{ inputs.coverage-threshold }}
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
+          set -o pipefail
           pip install pytest-cov
-          pytest "$TESTS_DIR" -v \
-            --cov \
-            --cov-report=term-missing \
-            --cov-fail-under="$COV_THRESHOLD"
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pytest "$TESTS_DIR" -v \
+              --cov \
+              --cov-report=term-missing \
+              --cov-fail-under="$COV_THRESHOLD" 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest-cov.log"
+          else
+            pytest "$TESTS_DIR" -v \
+              --cov \
+              --cov-report=term-missing \
+              --cov-fail-under="$COV_THRESHOLD"
+          fi
+
+      - name: Configure AWS credentials for logging
+        if: always() && inputs.enable-ci-logs
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        run: |
+          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
+          {
+            "repository": "${{ github.repository }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "actor": "${{ github.actor }}",
+            "event": "${{ github.event_name }}",
+            "job_status": "${{ job.status }}",
+            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          }
+          METAEOF
+          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -23,6 +23,22 @@ on:
         description: URL to curl after deploy for smoke test (optional)
         type: string
         default: ""
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: false
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "s3"
+      ci-log-s3-bucket:
+        description: S3 bucket for CI logs
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: CloudWatch Logs group name
+        type: string
+        default: "/github-actions/ci-cd"
 
 jobs:
   deploy:
@@ -35,6 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
+
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
@@ -42,10 +62,26 @@ jobs:
           requirements-path: ${{ inputs.infra-dir }}/requirements.txt
 
       - name: Install frontend dependencies
-        run: npm ci --prefix ${{ inputs.frontend-dir }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            npm ci --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-install.log"
+          else
+            npm ci --prefix ${{ inputs.frontend-dir }}
+          fi
 
       - name: Build frontend
-        run: npm run build --prefix ${{ inputs.frontend-dir }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            npm run build --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-build.log"
+          else
+            npm run build --prefix ${{ inputs.frontend-dir }}
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -55,7 +91,15 @@ jobs:
 
       - name: CDK Deploy
         working-directory: ${{ inputs.infra-dir }}
-        run: cdk deploy --require-approval never --outputs-file outputs.json
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            cdk deploy --require-approval never --outputs-file outputs.json 2>&1 | tee "$RUNNER_TEMP/ci-logs/cdk-deploy.log"
+          else
+            cdk deploy --require-approval never --outputs-file outputs.json
+          fi
 
       - name: Upload stack outputs
         if: always()
@@ -79,14 +123,53 @@ jobs:
 
       - name: Smoke test
         if: ${{ inputs.smoke-test-url != '' }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
-          status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
-            "${{ inputs.smoke-test-url }}" || echo "000")
-          echo "Smoke test HTTP status: $status"
-          echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
-          echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "$status" == "000" ]]; then
-            echo "::warning::Smoke test: curl failed or timed out"
+          set -o pipefail
+          _run_smoke() {
+            status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
+              "${{ inputs.smoke-test-url }}" || echo "000")
+            echo "Smoke test HTTP status: $status"
+            echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
+            echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
+            if [[ "$status" == "000" ]]; then
+              echo "::warning::Smoke test: curl failed or timed out"
+            else
+              echo "Smoke test passed — endpoint is reachable."
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_smoke 2>&1 | tee "$RUNNER_TEMP/ci-logs/smoke-test.log"
           else
-            echo "Smoke test passed — endpoint is reachable."
+            _run_smoke
           fi
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        run: |
+          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
+          {
+            "repository": "${{ github.repository }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "actor": "${{ github.actor }}",
+            "event": "${{ github.event_name }}",
+            "job_status": "${{ job.status }}",
+            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          }
+          METAEOF
+          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -27,6 +27,22 @@ on:
         description: Set to true to skip the frontend test step (for repos without tests configured)
         type: boolean
         default: false
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: false
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "s3"
+      ci-log-s3-bucket:
+        description: S3 bucket for CI logs
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: CloudWatch Logs group name
+        type: string
+        default: "/github-actions/ci-cd"
 
 jobs:
   review:
@@ -39,6 +55,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
+
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
@@ -49,23 +69,63 @@ jobs:
         run: npm ci --prefix ${{ inputs.frontend-dir }}
 
       - name: Lint frontend (ESLint)
-        run: npm run lint --prefix ${{ inputs.frontend-dir }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            npm run lint --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/eslint.log"
+          else
+            npm run lint --prefix ${{ inputs.frontend-dir }}
+          fi
 
       - name: Test frontend (Vitest)
         if: ${{ !inputs.skip-frontend-tests }}
-        run: npm run test --prefix ${{ inputs.frontend-dir }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            npm run test --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/vitest.log"
+          else
+            npm run test --prefix ${{ inputs.frontend-dir }}
+          fi
 
       - name: Build frontend
-        run: npm run build --prefix ${{ inputs.frontend-dir }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            npm run build --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-build.log"
+          else
+            npm run build --prefix ${{ inputs.frontend-dir }}
+          fi
 
       - name: Install infra dev dependencies
         run: pip install -r ${{ inputs.infra-dir }}/requirements-dev.txt
 
       - name: Test infra (pytest)
-        run: pytest ${{ inputs.infra-dir }}/tests/ -v
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pytest ${{ inputs.infra-dir }}/tests/ -v 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest.log"
+          else
+            pytest ${{ inputs.infra-dir }}/tests/ -v
+          fi
 
       - name: Dependency audit
-        run: pip-audit -r ${{ inputs.infra-dir }}/requirements.txt
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pip-audit -r ${{ inputs.infra-dir }}/requirements.txt 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
+          else
+            pip-audit -r ${{ inputs.infra-dir }}/requirements.txt
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -75,11 +135,21 @@ jobs:
 
       - name: CDK Synth
         working-directory: ${{ inputs.infra-dir }}
-        run: cdk synth
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            cdk synth 2>&1 | tee "$RUNNER_TEMP/ci-logs/cdk-synth.log"
+          else
+            cdk synth
+          fi
 
       - name: CDK Diff
         id: diff
         working-directory: ${{ inputs.infra-dir }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           diff_output=$(cdk diff 2>&1) || true
           echo "$diff_output"
@@ -88,6 +158,9 @@ jobs:
             echo "$diff_output"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            echo "$diff_output" > "$RUNNER_TEMP/ci-logs/cdk-diff.log"
+          fi
 
       - name: Comment diff on PR
         uses: actions/github-script@v7
@@ -120,3 +193,32 @@ jobs:
                 body,
               });
             }
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        run: |
+          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
+          {
+            "repository": "${{ github.repository }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "actor": "${{ github.actor }}",
+            "event": "${{ github.event_name }}",
+            "job_status": "${{ job.status }}",
+            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          }
+          METAEOF
+          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
## Summary

- **New `ship-logs` composite action** (`.github/actions/ship-logs/action.yml`) that bundles step-level log files and ships them to S3 (as `logs.tar.gz` + `metadata.json`) and/or CloudWatch Logs (as structured log events with 90-day retention)
- **Integrated into all 5 CI/CD reusable workflows** (`cdk-deploy`, `cdk-review`, `static-site-deploy`, `static-site-review`, `python-ci`) — key steps capture output via `tee` to a log directory, with metadata and log shipping at the end of each run
- **Fully opt-in and backward-compatible** — four new inputs (`enable-ci-logs`, `ci-log-destination`, `ci-log-s3-bucket`, `ci-log-cloudwatch-group`) all default to off/empty, so existing callers are unaffected

### How callers enable it

```yaml
uses: Specter099/.github/.github/workflows/cdk-deploy.yml@main
with:
  enable-ci-logs: true
  ci-log-destination: both        # s3, cloudwatch, or both
  ci-log-s3-bucket: my-ci-logs-bucket
```

### S3 path structure
```
s3://{bucket}/ci-logs/{owner/repo}/{workflow}/{run-id}-{attempt}/
  ├── logs.tar.gz      # all step logs bundled
  └── metadata.json    # run context (repo, sha, actor, status, timestamp)
```

### CloudWatch structure
```
Log group:  /github-actions/ci-cd
Log stream: {owner/repo}/{workflow}/{run-id}-{attempt}
```

### IAM permissions needed (caller-side)
- S3: `s3:PutObject` on the log bucket
- CloudWatch: `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:PutLogEvents`, `logs:PutRetentionPolicy`

## Test plan

- [ ] Verify existing callers (without `enable-ci-logs`) behave identically — all new steps are gated behind `if: inputs.enable-ci-logs`
- [ ] Run a workflow with `enable-ci-logs: true` and `ci-log-destination: s3` — confirm `logs.tar.gz` and `metadata.json` appear at the expected S3 path
- [ ] Run with `ci-log-destination: cloudwatch` — confirm log group/stream are created and events are present
- [ ] Run with `ci-log-destination: both` — confirm both destinations receive logs
- [ ] Trigger a failing workflow run — confirm logs are still shipped (`if: always()`)
- [ ] `yamllint` passes on all modified files

https://claude.ai/code/session_01YAminup832nMVuSMRmKYRH