### PR TITLE
fix: resolve security and operational issues in CI/CD log shipping

### DIFF
--- a/.github/actions/ship-logs/action.yml
+++ b/.github/actions/ship-logs/action.yml
@@ -14,7 +14,7 @@ inputs:
   s3-bucket:
     description: S3 bucket name (required when destination includes s3)
     required: false
-    default: ""
+    default: "github-actions-logging-451645558365-us-east-1-an"
   s3-prefix:
     description: S3 key prefix inside the bucket
     required: false
@@ -22,7 +22,7 @@ inputs:
   cloudwatch-log-group:
     description: CloudWatch Logs log group name
     required: false
-    default: "/github-actions/ci-cd"
+    default: "github-actions-log-group"
   aws-region:
     description: AWS region
     required: false
@@ -34,20 +34,22 @@ runs:
     - name: Resolve log path variables
       id: vars
       shell: bash
+      env:
+        REPO: ${{ github.repository }}
+        WORKFLOW: ${{ github.workflow }}
+        RUN_ID: ${{ github.run_id }}
+        ATTEMPT: ${{ github.run_attempt }}
+        S3_PREFIX: ${{ inputs.s3-prefix }}
       run: |
-        REPO="${{ github.repository }}"
-        WORKFLOW="${{ github.workflow }}"
-        RUN_ID="${{ github.run_id }}"
-        ATTEMPT="${{ github.run_attempt }}"
-        # Sanitise workflow name for use as a path segment
-        SAFE_WORKFLOW=$(echo "$WORKFLOW" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
-        S3_KEY="${{ inputs.s3-prefix }}/${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}"
+        # Sanitise workflow name: keep only alphanumeric and hyphens
+        SAFE_WORKFLOW=$(echo "$WORKFLOW" | tr -cs 'a-zA-Z0-9-' '-' | tr '[:upper:]' '[:lower:]' | sed 's/^-//;s/-$//')
+        S3_KEY="${S3_PREFIX}/${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}"
         CW_STREAM="${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}"
         echo "s3-key=${S3_KEY}" >> "$GITHUB_OUTPUT"
         echo "cw-stream=${CW_STREAM}" >> "$GITHUB_OUTPUT"
 
     - name: Upload logs to S3
-      if: contains(inputs.destination, 's3') && inputs.s3-bucket != ''
+      if: (inputs.destination == 's3' || inputs.destination == 'both') && inputs.s3-bucket != ''
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
@@ -55,12 +57,9 @@ runs:
         S3_KEY: ${{ steps.vars.outputs.s3-key }}
       run: |
         set -euo pipefail
-        # Bundle all logs into a tarball
         tar czf "${RUNNER_TEMP}/ci-logs.tar.gz" -C "$LOG_DIR" .
-        # Upload tarball
         aws s3 cp "${RUNNER_TEMP}/ci-logs.tar.gz" \
           "s3://${S3_BUCKET}/${S3_KEY}/logs.tar.gz"
-        # Upload metadata separately for easy querying
         if [ -f "${LOG_DIR}/metadata.json" ]; then
           aws s3 cp "${LOG_DIR}/metadata.json" \
             "s3://${S3_BUCKET}/${S3_KEY}/metadata.json"
@@ -70,7 +69,7 @@ runs:
         echo "Logs uploaded to \`${S3_URI}\`" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Send logs to CloudWatch
-      if: contains(inputs.destination, 'cloudwatch')
+      if: inputs.destination == 'cloudwatch' || inputs.destination == 'both'
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
@@ -87,78 +86,84 @@ runs:
           --log-group-name "$LOG_GROUP" \
           --retention-in-days 90 \
           --region "$AWS_REGION" 2>/dev/null || true
-        # Create log stream
+        # Create log stream (ignore if exists on retry)
         aws logs create-log-stream \
           --log-group-name "$LOG_GROUP" \
           --log-stream-name "$LOG_STREAM" \
-          --region "$AWS_REGION"
-        # Send each log file as a batch of events
-        SEQUENCE_TOKEN=""
-        for logfile in "$LOG_DIR"/*.log; do
-          [ -f "$logfile" ] || continue
-          BASENAME=$(basename "$logfile")
-          # Build JSON log events array — one event per line, prefixed with filename
-          EVENTS="[]"
-          TS_MS=$(date +%s%3N)
-          while IFS= read -r line || [ -n "$line" ]; do
-            # Escape the line for JSON
-            ESCAPED=$(printf '%s' "$line" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()), end="")')
-            EVENTS=$(echo "$EVENTS" | python3 -c "
-        import json, sys
-        events = json.load(sys.stdin)
-        events.append({'timestamp': $TS_MS, 'message': '[${BASENAME}] ' + json.loads($ESCAPED)})
-        print(json.dumps(events))
-        ")
-            TS_MS=$((TS_MS + 1))
-          done < "$logfile"
-          # Skip empty files
-          EVENT_COUNT=$(echo "$EVENTS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
-          [ "$EVENT_COUNT" -eq 0 ] && continue
-          # put-log-events (max 1MB / 10000 events per call — CI logs are well under)
-          if [ -z "$SEQUENCE_TOKEN" ]; then
-            RESULT=$(aws logs put-log-events \
-              --log-group-name "$LOG_GROUP" \
-              --log-stream-name "$LOG_STREAM" \
-              --log-events "$EVENTS" \
-              --region "$AWS_REGION" 2>&1) || true
-          else
-            RESULT=$(aws logs put-log-events \
-              --log-group-name "$LOG_GROUP" \
-              --log-stream-name "$LOG_STREAM" \
-              --log-events "$EVENTS" \
-              --sequence-token "$SEQUENCE_TOKEN" \
-              --region "$AWS_REGION" 2>&1) || true
-          fi
-          # Extract next sequence token for subsequent puts
-          SEQUENCE_TOKEN=$(echo "$RESULT" | python3 -c "
-        import json, sys
-        try:
-            print(json.loads(sys.stdin.read()).get('nextSequenceToken',''))
-        except Exception:
-            print('')
-        " 2>/dev/null) || true
-        done
-        # Also send metadata.json as a single event
-        if [ -f "${LOG_DIR}/metadata.json" ]; then
-          META=$(cat "${LOG_DIR}/metadata.json")
-          META_ESCAPED=$(printf '%s' "$META" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()), end="")')
-          META_TS=$(date +%s%3N)
-          META_EVENTS="[{\"timestamp\": ${META_TS}, \"message\": $(echo "$META_ESCAPED")}]"
-          if [ -z "$SEQUENCE_TOKEN" ]; then
-            aws logs put-log-events \
-              --log-group-name "$LOG_GROUP" \
-              --log-stream-name "$LOG_STREAM" \
-              --log-events "$META_EVENTS" \
-              --region "$AWS_REGION" 2>/dev/null || true
-          else
-            aws logs put-log-events \
-              --log-group-name "$LOG_GROUP" \
-              --log-stream-name "$LOG_STREAM" \
-              --log-events "$META_EVENTS" \
-              --sequence-token "$SEQUENCE_TOKEN" \
-              --region "$AWS_REGION" 2>/dev/null || true
-          fi
-        fi
+          --region "$AWS_REGION" 2>/dev/null || true
+
+        # Build all events in a single Python invocation and upload via file
+        python3 << 'PYEOF'
+        import json
+        import os
+        import subprocess
+        import sys
+        import time
+        from pathlib import Path
+
+        log_dir    = Path(os.environ["LOG_DIR"])
+        log_group  = os.environ["LOG_GROUP"]
+        log_stream = os.environ["LOG_STREAM"]
+        region     = os.environ["AWS_REGION"]
+
+        sequence_token = None
+
+        def put_events(events):
+            """Send a batch of events to CloudWatch, returning the next sequence token."""
+            global sequence_token
+            if not events:
+                return
+            events_file = Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "cw-events.json"
+            events_file.write_text(json.dumps(events))
+            cmd = [
+                "aws", "logs", "put-log-events",
+                "--log-group-name", log_group,
+                "--log-stream-name", log_stream,
+                "--log-events", f"file://{events_file}",
+                "--region", region,
+            ]
+            if sequence_token:
+                cmd += ["--sequence-token", sequence_token]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode == 0:
+                try:
+                    sequence_token = json.loads(result.stdout).get("nextSequenceToken")
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+            else:
+                print(f"Warning: put-log-events failed: {result.stderr.strip()}", file=sys.stderr)
+
+        # Process each log file
+        for logfile in sorted(log_dir.glob("*.log")):
+            lines = logfile.read_text(errors="replace").splitlines()
+            if not lines:
+                continue
+            basename = logfile.name
+            ts_ms = int(time.time() * 1000)
+            # CloudWatch limit: 10,000 events / 1MB per put-log-events call
+            batch = []
+            batch_size = 0
+            for i, line in enumerate(lines):
+                message = f"[{basename}] {line}"
+                event = {"timestamp": ts_ms + i, "message": message}
+                event_size = len(json.dumps(event)) + 26  # overhead per event
+                if len(batch) >= 9000 or batch_size + event_size > 900_000:
+                    put_events(batch)
+                    batch = []
+                    batch_size = 0
+                batch.append(event)
+                batch_size += event_size
+            put_events(batch)
+
+        # Send metadata.json as a single event
+        metadata_path = log_dir / "metadata.json"
+        if metadata_path.exists():
+            meta_content = metadata_path.read_text(errors="replace")
+            put_events([{
+                "timestamp": int(time.time() * 1000),
+                "message": meta_content,
+            }])
+        PYEOF
         echo "## CI Logs — CloudWatch" >> "$GITHUB_STEP_SUMMARY"
         echo "Log group: \`${LOG_GROUP}\`  " >> "$GITHUB_STEP_SUMMARY"
         echo "Log stream: \`${LOG_STREAM}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -34,11 +34,11 @@ on:
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string
-        default: ""
+        default: "github-actions-logging-451645558365-us-east-1-an"
       ci-log-cloudwatch-group:
         description: CloudWatch Logs group name
         type: string
-        default: "/github-actions/ci-cd"
+        default: "github-actions-log-group"
 jobs:
   deploy:
     name: Deploy
@@ -123,22 +123,34 @@ jobs:
 
       - name: Generate log metadata
         if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
         run: |
-          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
-          {
-            "repository": "${{ github.repository }}",
-            "workflow": "${{ github.workflow }}",
-            "run_id": "${{ github.run_id }}",
-            "run_attempt": "${{ github.run_attempt }}",
-            "ref": "${{ github.ref }}",
-            "sha": "${{ github.sha }}",
-            "actor": "${{ github.actor }}",
-            "event": "${{ github.event_name }}",
-            "job_status": "${{ job.status }}",
-            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
-          METAEOF
-          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
 
       - name: Ship CI logs
         if: always() && inputs.enable-ci-logs

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -27,11 +27,11 @@ name: CDK Review
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string
-        default: ""
+        default: "github-actions-logging-451645558365-us-east-1-an"
       ci-log-cloudwatch-group:
         description: CloudWatch Logs group name
         type: string
-        default: "/github-actions/ci-cd"
+        default: "github-actions-log-group"
     secrets:
       AWS_ROLE_ARN:
         description: >-
@@ -225,25 +225,37 @@ jobs:
 
       - name: Generate log metadata
         if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
         run: |
-          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
-          {
-            "repository": "${{ github.repository }}",
-            "workflow": "${{ github.workflow }}",
-            "run_id": "${{ github.run_id }}",
-            "run_attempt": "${{ github.run_attempt }}",
-            "ref": "${{ github.ref }}",
-            "sha": "${{ github.sha }}",
-            "actor": "${{ github.actor }}",
-            "event": "${{ github.event_name }}",
-            "job_status": "${{ job.status }}",
-            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
-          METAEOF
-          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
 
       - name: Ship CI logs
-        if: always() && inputs.enable-ci-logs
+        if: always() && inputs.enable-ci-logs && env.AWS_ROLE_ARN != ''
         uses: Specter099/.github/.github/actions/ship-logs@main
         with:
           log-dir: ${{ runner.temp }}/ci-logs

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -60,11 +60,11 @@ name: Python CI
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string
-        default: ""
+        default: "github-actions-logging-451645558365-us-east-1-an"
       ci-log-cloudwatch-group:
         description: CloudWatch Logs group name
         type: string
-        default: "/github-actions/ci-cd"
+        default: "github-actions-log-group"
       aws-region:
         description: AWS region (used for CI log shipping)
         type: string
@@ -80,6 +80,8 @@ jobs:
     name: "Lint, Secrets & Test (py${{ matrix.python-version }})"
     runs-on: ubuntu-latest
     permissions:
+      # id-token: write is needed for OIDC when enable-ci-logs is true.
+      # The OIDC credential step itself is gated behind enable-ci-logs.
       id-token: write
       contents: read
     strategy:
@@ -212,22 +214,34 @@ jobs:
 
       - name: Generate log metadata
         if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
         run: |
-          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
-          {
-            "repository": "${{ github.repository }}",
-            "workflow": "${{ github.workflow }}",
-            "run_id": "${{ github.run_id }}",
-            "run_attempt": "${{ github.run_attempt }}",
-            "ref": "${{ github.ref }}",
-            "sha": "${{ github.sha }}",
-            "actor": "${{ github.actor }}",
-            "event": "${{ github.event_name }}",
-            "job_status": "${{ job.status }}",
-            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
-          METAEOF
-          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
 
       - name: Ship CI logs
         if: always() && inputs.enable-ci-logs

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -34,11 +34,11 @@ on:
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string
-        default: ""
+        default: "github-actions-logging-451645558365-us-east-1-an"
       ci-log-cloudwatch-group:
         description: CloudWatch Logs group name
         type: string
-        default: "/github-actions/ci-cd"
+        default: "github-actions-log-group"
 
 jobs:
   deploy:
@@ -147,22 +147,34 @@ jobs:
 
       - name: Generate log metadata
         if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
         run: |
-          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
-          {
-            "repository": "${{ github.repository }}",
-            "workflow": "${{ github.workflow }}",
-            "run_id": "${{ github.run_id }}",
-            "run_attempt": "${{ github.run_attempt }}",
-            "ref": "${{ github.ref }}",
-            "sha": "${{ github.sha }}",
-            "actor": "${{ github.actor }}",
-            "event": "${{ github.event_name }}",
-            "job_status": "${{ job.status }}",
-            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
-          METAEOF
-          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
 
       - name: Ship CI logs
         if: always() && inputs.enable-ci-logs

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -38,11 +38,11 @@ on:
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string
-        default: ""
+        default: "github-actions-logging-451645558365-us-east-1-an"
       ci-log-cloudwatch-group:
         description: CloudWatch Logs group name
         type: string
-        default: "/github-actions/ci-cd"
+        default: "github-actions-log-group"
 
 jobs:
   review:
@@ -196,22 +196,34 @@ jobs:
 
       - name: Generate log metadata
         if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
         run: |
-          cat > "$RUNNER_TEMP/ci-logs/metadata.json" << 'METAEOF'
-          {
-            "repository": "${{ github.repository }}",
-            "workflow": "${{ github.workflow }}",
-            "run_id": "${{ github.run_id }}",
-            "run_attempt": "${{ github.run_attempt }}",
-            "ref": "${{ github.ref }}",
-            "sha": "${{ github.sha }}",
-            "actor": "${{ github.actor }}",
-            "event": "${{ github.event_name }}",
-            "job_status": "${{ job.status }}",
-            "timestamp": "TIMESTAMP_PLACEHOLDER"
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
-          METAEOF
-          sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u +%Y-%m-%dT%H:%M:%SZ)/" "$RUNNER_TEMP/ci-logs/metadata.json"
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
 
       - name: Ship CI logs
         if: always() && inputs.enable-ci-logs


### PR DESCRIPTION
## Summary

Deep review of the CI/CD log shipping feature (#38) uncovered **3 critical, 3 high, and 2 medium** issues. This PR fixes all of them.

### Critical fixes
- **`destination: both` shipped to neither S3 nor CloudWatch** — `contains('both', 's3')` is false; replaced with explicit `==` checks
- **CloudWatch log shipping was broken** — per-line Python process spawning had a JSON quoting collision that caused `json.JSONDecodeError`, spawned ~2 python3 procs per log line (extreme perf cost), and passed the full events array as a CLI arg (ARG_MAX risk). Replaced with a single Python script that builds events in-memory and uploads via `file://`
- **Script injection via `${{ github.workflow }}`** — caller-controlled values were interpolated directly into `run:` shell blocks. Moved all `${{ }}` expressions into `env:` blocks across the ship-logs action and all 5 workflow metadata steps

### High fixes
- **`create-log-stream` failed on retry** — added `|| true` (matching `create-log-group`)
- **metadata.json invalid when context values contain `"`** — replaced heredoc+sed with `python3 json.dump()` via env vars for guaranteed valid JSON
- **`cdk-review.yml` log shipping failed when `AWS_ROLE_ARN` absent** — added `&& env.AWS_ROLE_ARN != ''` guard to the ship-logs step

### Medium fixes
- **`python-ci.yml` `id-token: write` permission** — documented why it's needed (OIDC for log shipping) with inline comment
- **Incomplete workflow name sanitization** — now strips all non-alphanumeric chars (was only replacing spaces)

### Defaults updated
- S3 bucket: `github-actions-logging-451645558365-us-east-1-an`
- CloudWatch log group: `github-actions-log-group`

## Test plan

- [ ] `yamllint` passes on all 6 modified files (verified locally)
- [ ] Existing callers without `enable-ci-logs` are unaffected (all new steps remain gated)
- [ ] `destination: s3` uploads tarball + metadata to S3
- [ ] `destination: cloudwatch` creates log group/stream and sends events
- [ ] `destination: both` ships to both destinations
- [ ] Failing workflow still ships logs (`if: always()`)
- [ ] Re-run of a workflow doesn't fail on existing log stream
- [ ] `cdk-review` with `enable-ci-logs: true` but no `AWS_ROLE_ARN` skips log shipping gracefully

https://claude.ai/code/session_01YAminup832nMVuSMRmKYRH