### PR TITLE
fix: change ci-log-destination default from "s3" to "both"

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -30,7 +30,7 @@ on:
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string
-        default: "s3"
+        default: "both"
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -23,7 +23,7 @@ name: CDK Review
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string
-        default: "s3"
+        default: "both"
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -56,7 +56,7 @@ name: Python CI
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string
-        default: "s3"
+        default: "both"
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -30,7 +30,7 @@ on:
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string
-        default: "s3"
+        default: "both"
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -34,7 +34,7 @@ on:
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string
-        default: "s3"
+        default: "both"
       ci-log-s3-bucket:
         description: S3 bucket for CI logs
         type: string


### PR DESCRIPTION
## Summary
- Changes `ci-log-destination` input default from `"s3"` to `"both"` in all 5 reusable workflows
- Affected: `cdk-deploy.yml`, `cdk-review.yml`, `python-ci.yml`, `static-site-deploy.yml`, `static-site-review.yml`
- No logic changes — only the default value for the input parameter

## Test plan
- [ ] Verify a workflow run that doesn't explicitly pass `ci-log-destination` now ships logs to both S3 and CloudWatch
- [ ] Verify callers that explicitly pass `ci-log-destination: s3` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)