### PR TITLE
fix: default enable-ci-logs to true in all reusable workflows

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -26,7 +26,7 @@ on:
       enable-ci-logs:
         description: Ship detailed step logs to S3/CloudWatch
         type: boolean
-        default: false
+        default: true
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -19,7 +19,7 @@ name: CDK Review
       enable-ci-logs:
         description: Ship detailed step logs to S3/CloudWatch
         type: boolean
-        default: false
+        default: true
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -52,7 +52,7 @@ name: Python CI
       enable-ci-logs:
         description: Ship detailed step logs to S3/CloudWatch
         type: boolean
-        default: false
+        default: true
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -26,7 +26,7 @@ on:
       enable-ci-logs:
         description: Ship detailed step logs to S3/CloudWatch
         type: boolean
-        default: false
+        default: true
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -30,7 +30,7 @@ on:
       enable-ci-logs:
         description: Ship detailed step logs to S3/CloudWatch
         type: boolean
-        default: false
+        default: true
       ci-log-destination:
         description: "Log destination: s3, cloudwatch, or both"
         type: string


### PR DESCRIPTION
## Summary
- Changes `default: false` → `default: true` for the `enable-ci-logs` input in all 5 reusable workflows: `python-ci`, `cdk-deploy`, `cdk-review`, `static-site-deploy`, `static-site-review`
- Callers now get CI log shipping (S3/CloudWatch) by default without needing to opt in explicitly

## Test plan
- [ ] Verify a workflow run that omits `enable-ci-logs` now ships logs
- [ ] Verify callers that explicitly pass `enable-ci-logs: false` still suppress logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)