### PR TITLE
feat(cdk-deploy): --verbose flag, per-line timestamps, setup version logs

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -59,6 +59,19 @@ jobs:
         with:
           cdk-version: ${{ inputs.cdk-version }}
 
+      - name: Capture setup versions
+        if: ${{ inputs.enable-ci-logs }}
+        run: |
+          {
+            echo "=== Setup Versions ==="
+            echo "node: $(node --version)"
+            echo "npm:  $(npm --version)"
+            echo "cdk:  $(cdk --version)"
+            echo "python3: $(python3 --version)"
+            echo "pip3:    $(pip3 --version)"
+            echo "aws-cli: $(aws --version 2>&1)"
+          } | tee "$RUNNER_TEMP/ci-logs/setup-versions.log"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -72,9 +85,11 @@ jobs:
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            cdk deploy $CDK_STACKS --require-approval never --outputs-file outputs.json 2>&1 | tee "$RUNNER_TEMP/ci-logs/cdk-deploy.log"
+            cdk deploy $CDK_STACKS --require-approval never --verbose --outputs-file outputs.json 2>&1 \
+              | awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' \
+              | tee "$RUNNER_TEMP/ci-logs/cdk-deploy.log"
           else
-            cdk deploy $CDK_STACKS --require-approval never --outputs-file outputs.json
+            cdk deploy $CDK_STACKS --require-approval never --verbose --outputs-file outputs.json
           fi
 
       - name: Upload stack outputs
@@ -116,7 +131,9 @@ jobs:
             fi
           }
           if [ "$ENABLE_LOGS" = "true" ]; then
-            _run_smoke 2>&1 | tee "$RUNNER_TEMP/ci-logs/smoke-test.log"
+            _run_smoke 2>&1 \
+              | awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' \
+              | tee "$RUNNER_TEMP/ci-logs/smoke-test.log"
           else
             _run_smoke
           fi


### PR DESCRIPTION
## Summary

- **`--verbose` on `cdk deploy`** — emits CloudFormation resource-level events (CREATE_IN_PROGRESS, UPDATE_COMPLETE, etc.) so you can see exactly what each stack change did.
- **Per-line ISO-8601 timestamps** — both the CDK deploy and smoke test log pipelines now pass through `awk strftime` before `tee`, so every line in `cdk-deploy.log` and `smoke-test.log` is prefixed with `2026-04-12T15:03:42Z`.
- **Setup version capture** — new step after `setup-cdk` writes `node`, `npm`, `cdk`, `python3`, `pip3`, and `aws-cli` versions to `ci-logs/setup-versions.log` (guarded by `enable-ci-logs`, same as all other log steps).

## Test plan

- [ ] Trigger a downstream workflow that calls `cdk-deploy.yml`; confirm `cdk-deploy.log` lines are timestamp-prefixed
- [ ] Confirm CloudFormation resource events appear in deploy output (verbose mode)
- [ ] Check S3/CloudWatch for `setup-versions.log` alongside the other log files
- [ ] Verify smoke test log also has timestamps when `enable-ci-logs: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)