### PR TITLE
feat: run IAM Access Analyzer in cdk-review on PRs

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -16,6 +16,12 @@ name: CDK Review
         description: URL to curl after deploy (optional)
         type: string
         default: ""
+      enable-access-analyzer:
+        description: >-
+          Run IAM Access Analyzer CheckNoPublicAccess against synthesized
+          templates (requires AWS_ROLE_ARN).
+        type: boolean
+        default: true
     secrets:
       AWS_ROLE_ARN:
         description: >-
@@ -86,6 +92,13 @@ jobs:
       - name: CDK Synth
         if: env.AWS_ROLE_ARN != ''
         run: cdk synth
+
+      - name: IAM Access Analyzer — no public access
+        if: env.AWS_ROLE_ARN != '' && inputs.enable-access-analyzer
+        uses: Specter099/.github/.github/actions/access-analyzer@main
+        with:
+          template-dir: cdk.out
+          aws-region: ${{ inputs.aws-region }}
 
       - name: SAST scan (bandit)
         run: |


### PR DESCRIPTION
## Summary
- Add `enable-access-analyzer` input (default `true`) to `cdk-review.yml`
- Invoke the existing `access-analyzer` composite action after `cdk synth`
- Shifts no-public-access enforcement from CD to CI so violations block the PR, not the deploy

## Why
Access Analyzer was running in some caller repos' deploy workflows. Moving it into the shared CI workflow means every CDK repo gets it at PR time with no per-repo wiring, and callers can remove the check from their CD flow.

## Notes for reviewers
- Gated on `env.AWS_ROLE_ARN != ''` — same OIDC role the `cdk synth` / `cdk diff` steps already use, so no new credentials required.
- Opt-out via `enable-access-analyzer: false` for repos that need it off.
- Caller repos that currently call `access-analyzer-check.yml` from CD can drop that call in a follow-up.

## Test plan
- [ ] CI run on this PR confirms the new step executes (or is cleanly skipped when `AWS_ROLE_ARN` is absent)
- [ ] Smoke-test in one caller repo (e.g. `rosiesewstoo-com`) — pin to this branch via `@feat/cdk-review-access-analyzer` and verify the step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)