### PR TITLE
fix: close workflow command-injection via env-var passthrough

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -31,8 +31,12 @@ runs:
 
     - name: Install CDK CLI
       shell: bash
-      run: npm install -g aws-cdk@${{ inputs.cdk-version }}
+      env:
+        CDK_VERSION: ${{ inputs.cdk-version }}
+      run: npm install -g "aws-cdk@$CDK_VERSION"
 
     - name: Install Python dependencies
       shell: bash
-      run: pip install -r ${{ inputs.requirements-path }}
+      env:
+        REQUIREMENTS_PATH: ${{ inputs.requirements-path }}
+      run: pip install -r "$REQUIREMENTS_PATH"

--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -3,9 +3,13 @@ description: Install Python 3.12, Node 22, pinned CDK CLI, and Python dependenci
 
 inputs:
   cdk-version:
-    description: CDK CLI version to install
+    description: >-
+      CDK CLI version. Composite actions cannot read the `vars` context,
+      so callers must resolve `vars.CDK_CLI_VERSION` at the workflow level
+      and pass the result here. Falls back to the hardcoded default below
+      if empty.
     required: false
-    default: "2.1106.1"
+    default: ""
   requirements-path:
     description: Path to requirements.txt relative to repo root
     required: false
@@ -14,6 +18,15 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve CDK version
+      id: cdk-ver
+      shell: bash
+      env:
+        INPUT_VER: ${{ inputs.cdk-version }}
+      run: |
+        VER="${INPUT_VER:-2.1106.1}"
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
@@ -27,12 +40,12 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.npm
-        key: npm-${{ runner.os }}-cdk-${{ inputs.cdk-version }}
+        key: npm-${{ runner.os }}-cdk-${{ steps.cdk-ver.outputs.version }}
 
     - name: Install CDK CLI
       shell: bash
       env:
-        CDK_VERSION: ${{ inputs.cdk-version }}
+        CDK_VERSION: ${{ steps.cdk-ver.outputs.version }}
       run: npm install -g "aws-cdk@$CDK_VERSION"
 
     - name: Install Python dependencies

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -20,10 +20,11 @@ jobs:
 
       - name: Resolve inputs
         id: vars
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          REPO_NAME="${{ github.event.repository.name }}"
           DATE=$(date -u +%Y-%m-%d)
-          SHA="${{ github.sha }}"
+          SHA="$GITHUB_SHA"
           FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
           echo "s3-key=${REPO_NAME}/${FILENAME}" >> "$GITHUB_OUTPUT"
@@ -41,17 +42,26 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload to S3
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ vars.BACKUP_S3_BUCKET }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          aws s3 cp "${{ steps.vars.outputs.filename }}" \
-            "s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}"
+          aws s3 cp "$FILENAME" "s3://$S3_BUCKET/$S3_KEY"
 
       - name: Write job summary
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ vars.BACKUP_S3_BUCKET }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| S3 URI | \`s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Repo Backup"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Repository | \`${GITHUB_REPOSITORY}\` |"
+            echo "| Commit | \`${GITHUB_SHA}\` |"
+            echo "| Archive | \`${FILENAME}\` |"
+            echo "| Size | ${ARCHIVE_SIZE} |"
+            echo "| S3 URI | \`s3://${S3_BUCKET}/${S3_KEY}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -115,15 +115,18 @@ jobs:
       - name: Smoke test
         if: ${{ inputs.smoke-test-url != '' }}
         env:
+          SMOKE_TEST_URL: ${{ inputs.smoke-test-url }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           _run_smoke() {
             status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
-              "${{ inputs.smoke-test-url }}" || echo "000")
+              "$SMOKE_TEST_URL" || echo "000")
             echo "Smoke test HTTP status: $status"
-            echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
-            echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Smoke Test"
+              echo "Response from \`$SMOKE_TEST_URL\`: **HTTP $status**"
+            } >> "$GITHUB_STEP_SUMMARY"
             if [[ "$status" == "000" ]]; then
               echo "::warning::Smoke test: curl failed or timed out"
             else

--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -53,15 +53,16 @@ jobs:
 
       - name: Resolve inputs
         id: vars
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          S3_PREFIX_INPUT: ${{ inputs.s3-prefix }}
         run: |
-          REPO_NAME="${{ github.event.repository.name }}"
-          PREFIX="${{ inputs.s3-prefix }}"
+          PREFIX="$S3_PREFIX_INPUT"
           if [ -z "$PREFIX" ]; then
             PREFIX="$REPO_NAME"
           fi
           DATE=$(date -u +%Y-%m-%d)
-          SHA="${{ github.sha }}"
-          FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
+          FILENAME="${REPO_NAME}-${DATE}-${GITHUB_SHA:0:7}.zip"
           echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
           echo "s3-key=${PREFIX}/${FILENAME}" >> "$GITHUB_OUTPUT"
@@ -79,17 +80,26 @@ jobs:
           aws-region: ${{ inputs.aws-region }}
 
       - name: Upload to S3
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ inputs.s3-bucket }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          aws s3 cp "${{ steps.vars.outputs.filename }}" \
-            "s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}"
+          aws s3 cp "$FILENAME" "s3://$S3_BUCKET/$S3_KEY"
 
       - name: Write job summary
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ inputs.s3-bucket }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| S3 URI | \`s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Repo Backup"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Repository | \`${GITHUB_REPOSITORY}\` |"
+            echo "| Commit | \`${GITHUB_SHA}\` |"
+            echo "| Archive | \`${FILENAME}\` |"
+            echo "| Size | ${ARCHIVE_SIZE} |"
+            echo "| S3 URI | \`s3://${S3_BUCKET}/${S3_KEY}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -63,24 +63,26 @@ jobs:
 
       - name: Install frontend dependencies
         env:
+          FRONTEND_DIR: ${{ inputs.frontend-dir }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            npm ci --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-install.log"
+            npm ci --prefix "$FRONTEND_DIR" 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-install.log"
           else
-            npm ci --prefix ${{ inputs.frontend-dir }}
+            npm ci --prefix "$FRONTEND_DIR"
           fi
 
       - name: Build frontend
         env:
+          FRONTEND_DIR: ${{ inputs.frontend-dir }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            npm run build --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-build.log"
+            npm run build --prefix "$FRONTEND_DIR" 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-build.log"
           else
-            npm run build --prefix ${{ inputs.frontend-dir }}
+            npm run build --prefix "$FRONTEND_DIR"
           fi
 
       - name: Configure AWS credentials
@@ -111,11 +113,13 @@ jobs:
 
       - name: Write outputs to job summary
         if: always()
+        env:
+          INFRA_DIR: ${{ inputs.infra-dir }}
         run: |
-          if [ -f "${{ inputs.infra-dir }}/outputs.json" ]; then
+          if [ -f "$INFRA_DIR/outputs.json" ]; then
             echo "## Stack Outputs" >> "$GITHUB_STEP_SUMMARY"
             echo '```json' >> "$GITHUB_STEP_SUMMARY"
-            cat "${{ inputs.infra-dir }}/outputs.json" >> "$GITHUB_STEP_SUMMARY"
+            cat "$INFRA_DIR/outputs.json" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No stack outputs file found." >> "$GITHUB_STEP_SUMMARY"
@@ -124,15 +128,18 @@ jobs:
       - name: Smoke test
         if: ${{ inputs.smoke-test-url != '' }}
         env:
+          SMOKE_TEST_URL: ${{ inputs.smoke-test-url }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           _run_smoke() {
             status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
-              "${{ inputs.smoke-test-url }}" || echo "000")
+              "$SMOKE_TEST_URL" || echo "000")
             echo "Smoke test HTTP status: $status"
-            echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
-            echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Smoke Test"
+              echo "Response from \`$SMOKE_TEST_URL\`: **HTTP $status**"
+            } >> "$GITHUB_STEP_SUMMARY"
             if [[ "$status" == "000" ]]; then
               echo "::warning::Smoke test: curl failed or timed out"
             else

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -66,65 +66,74 @@ jobs:
           requirements-path: ${{ inputs.infra-dir }}/requirements.txt
 
       - name: Install frontend dependencies
-        run: npm ci --prefix ${{ inputs.frontend-dir }}
+        env:
+          FRONTEND_DIR: ${{ inputs.frontend-dir }}
+        run: npm ci --prefix "$FRONTEND_DIR"
 
       - name: Lint frontend (ESLint)
         env:
+          FRONTEND_DIR: ${{ inputs.frontend-dir }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            npm run lint --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/eslint.log"
+            npm run lint --prefix "$FRONTEND_DIR" 2>&1 | tee "$RUNNER_TEMP/ci-logs/eslint.log"
           else
-            npm run lint --prefix ${{ inputs.frontend-dir }}
+            npm run lint --prefix "$FRONTEND_DIR"
           fi
 
       - name: Test frontend (Vitest)
         if: ${{ !inputs.skip-frontend-tests }}
         env:
+          FRONTEND_DIR: ${{ inputs.frontend-dir }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            npm run test --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/vitest.log"
+            npm run test --prefix "$FRONTEND_DIR" 2>&1 | tee "$RUNNER_TEMP/ci-logs/vitest.log"
           else
-            npm run test --prefix ${{ inputs.frontend-dir }}
+            npm run test --prefix "$FRONTEND_DIR"
           fi
 
       - name: Build frontend
         env:
+          FRONTEND_DIR: ${{ inputs.frontend-dir }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            npm run build --prefix ${{ inputs.frontend-dir }} 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-build.log"
+            npm run build --prefix "$FRONTEND_DIR" 2>&1 | tee "$RUNNER_TEMP/ci-logs/npm-build.log"
           else
-            npm run build --prefix ${{ inputs.frontend-dir }}
+            npm run build --prefix "$FRONTEND_DIR"
           fi
 
       - name: Install infra dev dependencies
-        run: pip install -r ${{ inputs.infra-dir }}/requirements-dev.txt
+        env:
+          INFRA_DIR: ${{ inputs.infra-dir }}
+        run: pip install -r "$INFRA_DIR/requirements-dev.txt"
 
       - name: Test infra (pytest)
         env:
+          INFRA_DIR: ${{ inputs.infra-dir }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            pytest ${{ inputs.infra-dir }}/tests/ -v 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest.log"
+            pytest "$INFRA_DIR/tests/" -v 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest.log"
           else
-            pytest ${{ inputs.infra-dir }}/tests/ -v
+            pytest "$INFRA_DIR/tests/" -v
           fi
 
       - name: Dependency audit
         env:
+          INFRA_DIR: ${{ inputs.infra-dir }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           if [ "$ENABLE_LOGS" = "true" ]; then
-            pip-audit -r ${{ inputs.infra-dir }}/requirements.txt 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
+            pip-audit -r "$INFRA_DIR/requirements.txt" 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
           else
-            pip-audit -r ${{ inputs.infra-dir }}/requirements.txt
+            pip-audit -r "$INFRA_DIR/requirements.txt"
           fi
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary

Closes GitHub Actions script-injection surface surfaced in the workflow review. All caller-controlled `${{ inputs.* }}` values that were interpolated directly into shell `run:` blocks are now passed via `env:` and referenced as quoted shell variables — the standard pattern already used in `python-ci.yml`.

## What changed

- `static-site-review.yml` · `static-site-deploy.yml` — `frontend-dir`, `infra-dir`, `smoke-test-url` now env-var'd
- `cdk-deploy.yml` — `smoke-test-url` env-var'd
- `repo-backup.yml` · `backup.yml` — `s3-prefix`, `s3-bucket`, and `github.sha`/`github.repository` now use GitHub's built-in `GITHUB_*` env vars instead of template interpolation
- `actions/setup-cdk/action.yml` — `cdk-version`, `requirements-path` env-var'd

No behavioral changes. No new features. Aligns with the "all checks in CI, CD only deploys" mental model — this PR touches only the injection surface, not the check/deploy split.

## Test plan

- [ ] `yamllint -c .yamllint.yml .github/` is clean (verified locally)
- [ ] Re-run a caller repo's review workflow and confirm lint/test/synth/diff pass
- [ ] Re-run the caller's deploy workflow and confirm smoke-test step still renders the URL correctly in the job summary
- [ ] Trigger `backup.yml` via `workflow_dispatch` and confirm S3 upload + summary table render

## Notes

- `cdk-deploy.yml`'s `$CDK_STACKS` remains unquoted — intentional to allow `--all` or space-separated stack names. Same safety profile (env-var passthrough, trusted-caller model).
- The earlier review suggestion to add a "pre-deploy diff + Access Analyzer gate inside `cdk-deploy.yml`" is explicitly **not** in this PR — CD stays deploy-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)