### PR TITLE
refactor(ci): centralize CI log + CDK version defaults via org vars

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -3,9 +3,11 @@ description: Install Python 3.12, Node 22, pinned CDK CLI, and Python dependenci
 
 inputs:
   cdk-version:
-    description: CDK CLI version to install
+    description: >-
+      CDK CLI version. Empty/unset falls back to vars.CDK_CLI_VERSION, then
+      to the hardcoded default below.
     required: false
-    default: "2.1106.1"
+    default: ""
   requirements-path:
     description: Path to requirements.txt relative to repo root
     required: false
@@ -14,6 +16,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve CDK version
+      id: cdk-ver
+      shell: bash
+      env:
+        INPUT_VER: ${{ inputs.cdk-version }}
+        VAR_VER: ${{ vars.CDK_CLI_VERSION }}
+      run: |
+        VER="${INPUT_VER:-${VAR_VER:-2.1106.1}}"
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
@@ -27,11 +39,11 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.npm
-        key: npm-${{ runner.os }}-cdk-${{ inputs.cdk-version }}
+        key: npm-${{ runner.os }}-cdk-${{ steps.cdk-ver.outputs.version }}
 
     - name: Install CDK CLI
       shell: bash
-      run: npm install -g aws-cdk@${{ inputs.cdk-version }}
+      run: npm install -g aws-cdk@${{ steps.cdk-ver.outputs.version }}
 
     - name: Install Python dependencies
       shell: bash

--- a/.github/actions/ship-logs/action.yml
+++ b/.github/actions/ship-logs/action.yml
@@ -12,17 +12,22 @@ inputs:
     required: false
     default: "s3"
   s3-bucket:
-    description: S3 bucket name (required when destination includes s3)
+    description: >-
+      S3 bucket name. Empty/unset falls back to vars.CI_LOGS_BUCKET; if that
+      is also unset, the S3 upload step is skipped.
     required: false
-    default: "github-actions-logging-451645558365-us-east-1-an"
+    default: ""
   s3-prefix:
     description: S3 key prefix inside the bucket
     required: false
     default: "ci-logs"
   cloudwatch-log-group:
-    description: CloudWatch Logs log group name
+    description: >-
+      CloudWatch Logs log group name. Empty/unset falls back to
+      vars.CI_LOGS_LOG_GROUP; if that is also unset, the CloudWatch upload
+      step is skipped.
     required: false
-    default: "github-actions-log-group"
+    default: ""
   aws-region:
     description: AWS region
     required: false
@@ -49,11 +54,11 @@ runs:
         echo "cw-stream=${CW_STREAM}" >> "$GITHUB_OUTPUT"
 
     - name: Upload logs to S3
-      if: (inputs.destination == 's3' || inputs.destination == 'both') && inputs.s3-bucket != ''
+      if: (inputs.destination == 's3' || inputs.destination == 'both') && (inputs.s3-bucket != '' || vars.CI_LOGS_BUCKET != '')
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
-        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_BUCKET: ${{ inputs.s3-bucket || vars.CI_LOGS_BUCKET }}
         S3_KEY: ${{ steps.vars.outputs.s3-key }}
       run: |
         set -euo pipefail
@@ -69,11 +74,11 @@ runs:
         echo "Logs uploaded to \`${S3_URI}\`" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Send logs to CloudWatch
-      if: inputs.destination == 'cloudwatch' || inputs.destination == 'both'
+      if: (inputs.destination == 'cloudwatch' || inputs.destination == 'both') && (inputs.cloudwatch-log-group != '' || vars.CI_LOGS_LOG_GROUP != '')
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
-        LOG_GROUP: ${{ inputs.cloudwatch-log-group }}
+        LOG_GROUP: ${{ inputs.cloudwatch-log-group || vars.CI_LOGS_LOG_GROUP }}
         LOG_STREAM: ${{ steps.vars.outputs.cw-stream }}
         AWS_REGION: ${{ inputs.aws-region }}
       run: |

--- a/.github/actions/ship-logs/action.yml
+++ b/.github/actions/ship-logs/action.yml
@@ -13,8 +13,8 @@ inputs:
     default: "s3"
   s3-bucket:
     description: >-
-      S3 bucket name. Empty/unset falls back to vars.CI_LOGS_BUCKET; if that
-      is also unset, the S3 upload step is skipped.
+      S3 bucket name. Resolution order: input → vars.CI_LOGS_BUCKET →
+      hardcoded fallback below. The action is the canonical source of truth.
     required: false
     default: ""
   s3-prefix:
@@ -23,9 +23,8 @@ inputs:
     default: "ci-logs"
   cloudwatch-log-group:
     description: >-
-      CloudWatch Logs log group name. Empty/unset falls back to
-      vars.CI_LOGS_LOG_GROUP; if that is also unset, the CloudWatch upload
-      step is skipped.
+      CloudWatch Logs log group name. Resolution order: input →
+      vars.CI_LOGS_LOG_GROUP → hardcoded fallback below.
     required: false
     default: ""
   aws-region:
@@ -54,11 +53,11 @@ runs:
         echo "cw-stream=${CW_STREAM}" >> "$GITHUB_OUTPUT"
 
     - name: Upload logs to S3
-      if: (inputs.destination == 's3' || inputs.destination == 'both') && (inputs.s3-bucket != '' || vars.CI_LOGS_BUCKET != '')
+      if: inputs.destination == 's3' || inputs.destination == 'both'
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
-        S3_BUCKET: ${{ inputs.s3-bucket || vars.CI_LOGS_BUCKET }}
+        S3_BUCKET: ${{ inputs.s3-bucket || vars.CI_LOGS_BUCKET || 'github-actions-logging-451645558365-us-east-1-an' }}
         S3_KEY: ${{ steps.vars.outputs.s3-key }}
       run: |
         set -euo pipefail
@@ -74,11 +73,11 @@ runs:
         echo "Logs uploaded to \`${S3_URI}\`" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Send logs to CloudWatch
-      if: (inputs.destination == 'cloudwatch' || inputs.destination == 'both') && (inputs.cloudwatch-log-group != '' || vars.CI_LOGS_LOG_GROUP != '')
+      if: inputs.destination == 'cloudwatch' || inputs.destination == 'both'
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
-        LOG_GROUP: ${{ inputs.cloudwatch-log-group || vars.CI_LOGS_LOG_GROUP }}
+        LOG_GROUP: ${{ inputs.cloudwatch-log-group || vars.CI_LOGS_LOG_GROUP || 'github-actions-log-group' }}
         LOG_STREAM: ${{ steps.vars.outputs.cw-stream }}
         AWS_REGION: ${{ inputs.aws-region }}
       run: |

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -8,9 +8,11 @@ on:
         type: string
         default: "us-east-1"
       cdk-version:
-        description: CDK CLI npm version to install
+        description: >-
+          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
+          in the setup-cdk action.
         type: string
-        default: "2.1106.1"
+        default: ""
       stacks:
         description: Stack name(s) to deploy, or '--all' for all stacks
         type: string
@@ -32,13 +34,17 @@ on:
         type: string
         default: "both"
       ci-log-s3-bucket:
-        description: S3 bucket for CI logs
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
+          in the ship-logs action.
         type: string
-        default: "github-actions-logging-451645558365-us-east-1-an"
+        default: ""
       ci-log-cloudwatch-group:
-        description: CloudWatch Logs group name
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
         type: string
-        default: "github-actions-log-group"
+        default: ""
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -9,9 +9,11 @@ name: CDK Review
         type: string
         default: "us-east-1"
       cdk-version:
-        description: CDK CLI npm version to install
+        description: >-
+          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
+          in the setup-cdk action.
         type: string
-        default: "2.1106.1"
+        default: ""
       smoke-test-url:
         description: URL to curl after deploy (optional)
         type: string
@@ -31,13 +33,17 @@ name: CDK Review
         type: string
         default: "both"
       ci-log-s3-bucket:
-        description: S3 bucket for CI logs
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
+          in the ship-logs action.
         type: string
-        default: "github-actions-logging-451645558365-us-east-1-an"
+        default: ""
       ci-log-cloudwatch-group:
-        description: CloudWatch Logs group name
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
         type: string
-        default: "github-actions-log-group"
+        default: ""
     secrets:
       AWS_ROLE_ARN:
         description: >-

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -58,13 +58,17 @@ name: Python CI
         type: string
         default: "both"
       ci-log-s3-bucket:
-        description: S3 bucket for CI logs
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
+          in the ship-logs action.
         type: string
-        default: "github-actions-logging-451645558365-us-east-1-an"
+        default: ""
       ci-log-cloudwatch-group:
-        description: CloudWatch Logs group name
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
         type: string
-        default: "github-actions-log-group"
+        default: ""
       aws-region:
         description: AWS region (used for CI log shipping)
         type: string

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -16,9 +16,11 @@ on:
         type: string
         default: "us-east-1"
       cdk-version:
-        description: CDK CLI npm version
+        description: >-
+          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
+          in the setup-cdk action.
         type: string
-        default: "2.1106.1"
+        default: ""
       smoke-test-url:
         description: URL to curl after deploy for smoke test (optional)
         type: string
@@ -32,13 +34,17 @@ on:
         type: string
         default: "both"
       ci-log-s3-bucket:
-        description: S3 bucket for CI logs
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
+          in the ship-logs action.
         type: string
-        default: "github-actions-logging-451645558365-us-east-1-an"
+        default: ""
       ci-log-cloudwatch-group:
-        description: CloudWatch Logs group name
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
         type: string
-        default: "github-actions-log-group"
+        default: ""
 
 jobs:
   deploy:

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -16,9 +16,11 @@ on:
         type: string
         default: "us-east-1"
       cdk-version:
-        description: CDK CLI npm version
+        description: >-
+          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
+          in the setup-cdk action.
         type: string
-        default: "2.1106.1"
+        default: ""
       smoke-test-url:
         description: Unused in review — accepted for interface consistency with deploy workflow
         type: string
@@ -36,13 +38,17 @@ on:
         type: string
         default: "both"
       ci-log-s3-bucket:
-        description: S3 bucket for CI logs
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
+          in the ship-logs action.
         type: string
-        default: "github-actions-logging-451645558365-us-east-1-an"
+        default: ""
       ci-log-cloudwatch-group:
-        description: CloudWatch Logs group name
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
         type: string
-        default: "github-actions-log-group"
+        default: ""
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- Removed hardcoded duplicates of the CI logs S3 bucket name (5 workflows), CloudWatch log group (5 workflows), and CDK CLI version `2.1106.1` (4 workflows).
- Resolution order is now: workflow input → repo-level `vars.*` → action's hardcoded fallback. The 5 caller workflows pass empty defaults; the actions (`setup-cdk`, `ship-logs`) own the canonical resolution.
- The actions themselves are now the single source of truth — no per-repo setup required for backward compat.

## Architecture decision: Specter099 is a User, not an Org
Org-level GitHub Actions variables don't exist for user accounts, so the original design (vars.* as the single source of truth) wouldn't have worked without setting per-repo vars on every consuming repo. The composite actions now hold the canonical hardcoded values as a final fallback, with `vars.*` available as a per-repo override.

## Optional override
If you want a particular consuming repo to use a different bucket/log-group/CDK version, set the corresponding **repo-level** variable (Settings → Secrets and variables → Actions → Variables):

| Variable | Default in action |
|---|---|
| `CI_LOGS_BUCKET` | `github-actions-logging-451645558365-us-east-1-an` |
| `CI_LOGS_LOG_GROUP` | `github-actions-log-group` |
| `CDK_CLI_VERSION` | `2.1106.1` |

Or override per-call via the workflow input.

## Out of scope
- Org-name self-references (`Specter099/.github` in `uses:` and `with: repository:`) intentionally kept. `${{ github.repository_owner }}` would resolve to the *caller's* user/org and break those references.
- Medium/low-tier audit findings (`environment: production`, `--max-time 15`, etc.) — separate PR if desired.

## Test plan
- [ ] Trigger a `cdk-review` run on a downstream repo and confirm CDK install + log shipping still work without setting any vars
- [ ] Trigger a `python-ci` run and confirm CI logs land in S3
- [ ] Confirm `Setup CDK > Resolve CDK version` step output equals `2.1106.1` when no input or var is set
- [ ] Set a repo-level `vars.CDK_CLI_VERSION` on one repo and confirm the override is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)