### PR TITLE
fix: remove vars context usage from composite actions; redact account ID

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -4,8 +4,10 @@ description: Install Python 3.12, Node 22, pinned CDK CLI, and Python dependenci
 inputs:
   cdk-version:
     description: >-
-      CDK CLI version. Empty/unset falls back to vars.CDK_CLI_VERSION, then
-      to the hardcoded default below.
+      CDK CLI version. Composite actions cannot read the `vars` context,
+      so callers must resolve `vars.CDK_CLI_VERSION` at the workflow level
+      and pass the result here. Falls back to the hardcoded default below
+      if empty.
     required: false
     default: ""
   requirements-path:
@@ -21,9 +23,8 @@ runs:
       shell: bash
       env:
         INPUT_VER: ${{ inputs.cdk-version }}
-        VAR_VER: ${{ vars.CDK_CLI_VERSION }}
       run: |
-        VER="${INPUT_VER:-${VAR_VER:-2.1106.1}}"
+        VER="${INPUT_VER:-2.1106.1}"
         echo "version=$VER" >> "$GITHUB_OUTPUT"
 
     - uses: actions/setup-python@v5

--- a/.github/actions/ship-logs/action.yml
+++ b/.github/actions/ship-logs/action.yml
@@ -13,8 +13,9 @@ inputs:
     default: "s3"
   s3-bucket:
     description: >-
-      S3 bucket name. Resolution order: input → vars.CI_LOGS_BUCKET →
-      hardcoded fallback below. The action is the canonical source of truth.
+      S3 bucket name. Composite actions cannot read the `vars` context,
+      so callers must resolve `vars.CI_LOGS_BUCKET` at the workflow level
+      and pass the result here. The S3 upload step fails if empty.
     required: false
     default: ""
   s3-prefix:
@@ -23,8 +24,10 @@ inputs:
     default: "ci-logs"
   cloudwatch-log-group:
     description: >-
-      CloudWatch Logs log group name. Resolution order: input →
-      vars.CI_LOGS_LOG_GROUP → hardcoded fallback below.
+      CloudWatch Logs log group name. Composite actions cannot read the
+      `vars` context, so callers must resolve `vars.CI_LOGS_LOG_GROUP` at
+      the workflow level and pass the result here. The CloudWatch step
+      fails if empty.
     required: false
     default: ""
   aws-region:
@@ -57,10 +60,14 @@ runs:
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
-        S3_BUCKET: ${{ inputs.s3-bucket || vars.CI_LOGS_BUCKET || 'github-actions-logging-451645558365-us-east-1-an' }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_KEY: ${{ steps.vars.outputs.s3-key }}
       run: |
         set -euo pipefail
+        if [ -z "$S3_BUCKET" ]; then
+          echo "::error::ship-logs: s3-bucket input is empty. Set vars.CI_LOGS_BUCKET in the calling repo or pass ci-log-s3-bucket explicitly."
+          exit 1
+        fi
         tar czf "${RUNNER_TEMP}/ci-logs.tar.gz" -C "$LOG_DIR" .
         aws s3 cp "${RUNNER_TEMP}/ci-logs.tar.gz" \
           "s3://${S3_BUCKET}/${S3_KEY}/logs.tar.gz"
@@ -77,11 +84,15 @@ runs:
       shell: bash
       env:
         LOG_DIR: ${{ inputs.log-dir }}
-        LOG_GROUP: ${{ inputs.cloudwatch-log-group || vars.CI_LOGS_LOG_GROUP || 'github-actions-log-group' }}
+        LOG_GROUP: ${{ inputs.cloudwatch-log-group }}
         LOG_STREAM: ${{ steps.vars.outputs.cw-stream }}
         AWS_REGION: ${{ inputs.aws-region }}
       run: |
         set -euo pipefail
+        if [ -z "$LOG_GROUP" ]; then
+          echo "::error::ship-logs: cloudwatch-log-group input is empty. Set vars.CI_LOGS_LOG_GROUP in the calling repo or pass ci-log-cloudwatch-group explicitly."
+          exit 1
+        fi
         # Create log group (ignore if exists) with 90-day retention
         aws logs create-log-group \
           --log-group-name "$LOG_GROUP" \

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -9,8 +9,9 @@ on:
         default: "us-east-1"
       cdk-version:
         description: >-
-          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
-          in the setup-cdk action.
+          CDK CLI npm version. Empty/unset falls back to
+          `vars.CDK_CLI_VERSION` in the calling repo, then to the
+          hardcoded default in the setup-cdk action.
         type: string
         default: ""
       stacks:
@@ -35,14 +36,16 @@ on:
         default: "both"
       ci-log-s3-bucket:
         description: >-
-          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
-          in the ship-logs action.
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
         type: string
         default: ""
       ci-log-cloudwatch-group:
         description: >-
           CloudWatch Logs group name. Empty/unset falls back to
-          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
         type: string
         default: ""
 jobs:
@@ -63,7 +66,7 @@ jobs:
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
-          cdk-version: ${{ inputs.cdk-version }}
+          cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
 
       - name: Capture setup versions
         if: ${{ inputs.enable-ci-logs }}
@@ -181,6 +184,6 @@ jobs:
         with:
           log-dir: ${{ runner.temp }}/ci-logs
           destination: ${{ inputs.ci-log-destination }}
-          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
-          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -10,8 +10,9 @@ name: CDK Review
         default: "us-east-1"
       cdk-version:
         description: >-
-          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
-          in the setup-cdk action.
+          CDK CLI npm version. Empty/unset falls back to
+          `vars.CDK_CLI_VERSION` in the calling repo, then to the
+          hardcoded default in the setup-cdk action.
         type: string
         default: ""
       smoke-test-url:
@@ -34,14 +35,16 @@ name: CDK Review
         default: "both"
       ci-log-s3-bucket:
         description: >-
-          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
-          in the ship-logs action.
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
         type: string
         default: ""
       ci-log-cloudwatch-group:
         description: >-
           CloudWatch Logs group name. Empty/unset falls back to
-          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
         type: string
         default: ""
     secrets:
@@ -70,7 +73,7 @@ jobs:
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
-          cdk-version: ${{ inputs.cdk-version }}
+          cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
 
       - name: Install dependencies
         run: |
@@ -279,6 +282,6 @@ jobs:
         with:
           log-dir: ${{ runner.temp }}/ci-logs
           destination: ${{ inputs.ci-log-destination }}
-          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
-          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -59,14 +59,16 @@ name: Python CI
         default: "both"
       ci-log-s3-bucket:
         description: >-
-          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
-          in the ship-logs action.
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
         type: string
         default: ""
       ci-log-cloudwatch-group:
         description: >-
           CloudWatch Logs group name. Empty/unset falls back to
-          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
         type: string
         default: ""
       aws-region:
@@ -253,6 +255,6 @@ jobs:
         with:
           log-dir: ${{ runner.temp }}/ci-logs
           destination: ${{ inputs.ci-log-destination }}
-          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
-          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -17,8 +17,9 @@ on:
         default: "us-east-1"
       cdk-version:
         description: >-
-          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
-          in the setup-cdk action.
+          CDK CLI npm version. Empty/unset falls back to
+          `vars.CDK_CLI_VERSION` in the calling repo, then to the
+          hardcoded default in the setup-cdk action.
         type: string
         default: ""
       smoke-test-url:
@@ -35,14 +36,16 @@ on:
         default: "both"
       ci-log-s3-bucket:
         description: >-
-          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
-          in the ship-logs action.
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
         type: string
         default: ""
       ci-log-cloudwatch-group:
         description: >-
           CloudWatch Logs group name. Empty/unset falls back to
-          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
         type: string
         default: ""
 
@@ -64,7 +67,7 @@ jobs:
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
-          cdk-version: ${{ inputs.cdk-version }}
+          cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
           requirements-path: ${{ inputs.infra-dir }}/requirements.txt
 
       - name: Install frontend dependencies
@@ -188,6 +191,6 @@ jobs:
         with:
           log-dir: ${{ runner.temp }}/ci-logs
           destination: ${{ inputs.ci-log-destination }}
-          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
-          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -17,8 +17,9 @@ on:
         default: "us-east-1"
       cdk-version:
         description: >-
-          CDK CLI npm version. Empty/unset falls back to vars.CDK_CLI_VERSION
-          in the setup-cdk action.
+          CDK CLI npm version. Empty/unset falls back to
+          `vars.CDK_CLI_VERSION` in the calling repo, then to the
+          hardcoded default in the setup-cdk action.
         type: string
         default: ""
       smoke-test-url:
@@ -39,14 +40,16 @@ on:
         default: "both"
       ci-log-s3-bucket:
         description: >-
-          S3 bucket for CI logs. Empty/unset falls back to vars.CI_LOGS_BUCKET
-          in the ship-logs action.
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
         type: string
         default: ""
       ci-log-cloudwatch-group:
         description: >-
           CloudWatch Logs group name. Empty/unset falls back to
-          vars.CI_LOGS_LOG_GROUP in the ship-logs action.
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
         type: string
         default: ""
 
@@ -68,7 +71,7 @@ jobs:
       - name: Setup CDK
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
-          cdk-version: ${{ inputs.cdk-version }}
+          cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
           requirements-path: ${{ inputs.infra-dir }}/requirements.txt
 
       - name: Install frontend dependencies
@@ -237,6 +240,6 @@ jobs:
         with:
           log-dir: ${{ runner.temp }}/ci-logs
           destination: ${{ inputs.ci-log-destination }}
-          s3-bucket: ${{ inputs.ci-log-s3-bucket }}
-          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
           aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
## Why

Composite actions cannot access the `vars` context — only workflows can ([docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability)). The composite actions `setup-cdk` and `ship-logs` referenced `vars.CDK_CLI_VERSION`, `vars.CI_LOGS_BUCKET`, and `vars.CI_LOGS_LOG_GROUP`, which fails YAML schema validation at action-load time:

> ##[error]Specter099/.github/main/.github/actions/setup-cdk/action.yml (Line: 24, Col: 18): Unrecognized named-value: 'vars'. Located at position 1 within expression: vars.CDK_CLI_VERSION

Every consumer of the `cdk-deploy`, `cdk-review`, `static-site-deploy`, `static-site-review`, and `python-ci` reusable workflows hits this on the first step that uses these actions.

## Changes

- **`setup-cdk/action.yml`** — drop `VAR_VER` env line; rely on input + hardcoded `2.1106.1` final fallback.
- **`ship-logs/action.yml`** — drop `vars.X` references AND the hardcoded fallback `github-actions-logging-451645558365-us-east-1-an` (an AWS account ID in a public repo). Action now fails loudly with a clear error if input is empty.
- **All 5 reusable workflows** (`cdk-deploy`, `cdk-review`, `static-site-deploy`, `static-site-review`, `python-ci`) — resolve `vars.X` at the workflow `with:` line: `${{ inputs.X != '' && inputs.X || vars.X }}`.
- Doc strings updated to reflect the new resolution chain.

## Migration for consumers

Set repo-level Actions vars in each consumer:

```bash
gh variable set CDK_CLI_VERSION    --body "<version>"
gh variable set CI_LOGS_BUCKET     --body "<bucket-name>"
gh variable set CI_LOGS_LOG_GROUP  --body "<log-group>"
```

Without these, ship-logs will fail loudly during runs that have `enable-ci-logs: true`. setup-cdk falls back to `2.1106.1` if `CDK_CLI_VERSION` is unset.

## Consumers known to be affected
- `Specter099/certificate-factory` (companion vars-set PR coming)
- `Specter099/denali` (Deploy + PR Review broken since 2026-04-05)
- Any other consumer of the listed reusable workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)