### PR TITLE
feat: build Lambda layer in CI/CD when present

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
 
+      - name: Build Lambda layer
+        if: hashFiles('lambda_layer/requirements.txt') != ''
+        run: |
+          pip install -r lambda_layer/requirements.txt -t lambda_layer/python \
+            --platform manylinux2014_aarch64 --only-binary=:all: --quiet
+
       - name: Capture setup versions
         if: ${{ inputs.enable-ci-logs }}
         run: |

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -80,6 +80,12 @@ jobs:
           pip install -r requirements.txt
           [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
 
+      - name: Build Lambda layer
+        if: hashFiles('lambda_layer/requirements.txt') != ''
+        run: |
+          pip install -r lambda_layer/requirements.txt -t lambda_layer/python \
+            --platform manylinux2014_aarch64 --only-binary=:all: --quiet
+
       - name: Lint (ruff)
         if: hashFiles('requirements-dev.txt') != '' && success()
         env:


### PR DESCRIPTION
## Why

After the recent fixes landed, the first Deploy run on certificate-factory got past synth + AWS auth + `cdk deploy`, but the post-deploy custom resource (which triggers the Step Functions cert-issuance state machine) failed:

> Runtime.ImportModuleError: Unable to import module 'lambdas.steps.check_expiry': No module named 'cryptography'

Per the consumer's CLAUDE.md, the project's `lambda_layer/requirements.txt` is supposed to be pip-installed into `lambda_layer/python/` before `cdk synth`/`deploy` — that directory is what CDK packages as the LayerVersion asset, and it's `.gitignored`. The reusable workflow never did this, so every CI run shipped an empty layer.

## What

- **`cdk-deploy.yml`** and **`cdk-review.yml`**: new `Build Lambda layer` step inserted after `Setup CDK` / dependency install. Runs:
  ```bash
  pip install -r lambda_layer/requirements.txt -t lambda_layer/python \
    --platform manylinux2014_aarch64 --only-binary=:all: --quiet
  ```
- Gated by `if: hashFiles('lambda_layer/requirements.txt') != ''` — no-op for consumers without a layer.
- Built in **both** workflows so the CDK diff reviewers see (review-time synth) matches what gets shipped (deploy-time synth). ARM64 manylinux wheels are deterministic enough between runs that artifact handoff isn't needed.

## Test plan

- [ ] On certificate-factory, trigger a fresh PR Review run → diff should now reflect a populated layer asset.
- [ ] Merge to main → Deploy run reaches `cdk deploy` and the custom resource state machine runs the lambdas successfully (no `ImportModuleError`).
- [ ] Other CDK consumers without a `lambda_layer/` (e.g. `denali`) — workflow runs unchanged (step skipped via hashFiles guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)