### PR TITLE
revert+fix: drop layer build from workflows; fix bandit exclude

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -68,12 +68,6 @@ jobs:
         with:
           cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
 
-      - name: Build Lambda layer
-        if: hashFiles('lambda_layer/requirements.txt') != ''
-        run: |
-          pip install -r lambda_layer/requirements.txt -t lambda_layer/python \
-            --platform manylinux2014_aarch64 --only-binary=:all: --quiet
-
       - name: Capture setup versions
         if: ${{ inputs.enable-ci-logs }}
         run: |

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -80,12 +80,6 @@ jobs:
           pip install -r requirements.txt
           [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
 
-      - name: Build Lambda layer
-        if: hashFiles('lambda_layer/requirements.txt') != ''
-        run: |
-          pip install -r lambda_layer/requirements.txt -t lambda_layer/python \
-            --platform manylinux2014_aarch64 --only-binary=:all: --quiet
-
       - name: Lint (ruff)
         if: hashFiles('requirements-dev.txt') != '' && success()
         env:
@@ -180,9 +174,9 @@ jobs:
           set -o pipefail
           pip install bandit
           if [ "$ENABLE_LOGS" = "true" ]; then
-            bandit -r . -ll --exclude .venv,cdk.out 2>&1 | tee "$RUNNER_TEMP/ci-logs/bandit.log"
+            bandit -r . -ll --exclude ./.venv,./cdk.out,./lambda_layer 2>&1 | tee "$RUNNER_TEMP/ci-logs/bandit.log"
           else
-            bandit -r . -ll --exclude .venv,cdk.out
+            bandit -r . -ll --exclude ./.venv,./cdk.out,./lambda_layer
           fi
 
       - name: CDK Nag (informational)


### PR DESCRIPTION
## Why

PR #56 added a \`Build Lambda layer\` step to the cdk-deploy and cdk-review reusable workflows. After it merged, the cdk-review run on certificate-factory failed at the \`SAST scan (bandit)\` step — bandit found dozens of issues in the freshly-installed third-party packages (e.g. \`acme/_internal/tests/standalone_test.py\` using \`requests(verify=False)\`).

Two related bugs surfaced:
1. **The bandit exclude didn't work for cdk.out.** Verified locally with bandit 1.9.4: \`--exclude .venv,cdk.out\` lets cdk.out get scanned; \`--exclude ./.venv,./cdk.out\` properly excludes it. Bandit's substring match needs the same path prefix it uses internally when walking with \`-r .\`.
2. **Building the layer in the reusable workflow** is the wrong layer of abstraction — projects with a Lambda layer can self-heal in their own \`app.py\` (running \`pip install\` with a hash-marker guard before any CDK code), keeping the consumer self-contained and the reusable workflow generic.

## What

- Revert the \`Build Lambda layer\` step from both workflows.
- Fix the bandit invocation: \`--exclude ./.venv,./cdk.out,./lambda_layer\`. Adding \`./lambda_layer\` is forward-compatible: harmless for projects without one, prevents noise for projects that build their layer in the working tree before synth.

## Companion change

Consumer-side: certificate-factory will get an \`_ensure_lambda_layer()\` hook in its \`app.py\` to do the build at synth time, with a \`requirements.txt\`-hash marker so it's a no-op on cache hit. PR coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)