### PR TITLE
fix: upgrade pip and ignore unfixed CVE in pip-audit

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -157,11 +157,12 @@ jobs:
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
+          pip install --upgrade pip
           pip install pip-audit
           if [ "$ENABLE_LOGS" = "true" ]; then
-            pip-audit 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
+            pip-audit --ignore-vuln CVE-2026-3219 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
           else
-            pip-audit
+            pip-audit --ignore-vuln CVE-2026-3219
           fi
 
       - name: SAST scan (bandit)


### PR DESCRIPTION
## Summary

- pip 26.0.1 (pre-installed on GitHub runners) has two CVEs flagged by pip-audit:
  - **CVE-2026-6357**: fixed in pip 26.1 — resolved by adding `pip install --upgrade pip` before running pip-audit
  - **CVE-2026-3219**: no fix available yet — ignored via `--ignore-vuln CVE-2026-3219` until a patch is released
- This is the reusable workflow consumed by other repos, so the fix propagates to all callers

## Test plan

- [ ] CI pipeline passes on a repo that calls this reusable workflow with `pip-audit: true`
- [ ] Verify `pip install --upgrade pip` pulls pip >= 26.1
- [ ] Verify `--ignore-vuln CVE-2026-3219` suppresses the unfixed CVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)