### PR TITLE
fix: restore 19 files accidentally deleted by PR #64

### DIFF
--- a/.github/actions/access-analyzer/action.yml
+++ b/.github/actions/access-analyzer/action.yml
@@ -1,0 +1,183 @@
+name: IAM Access Analyzer — Check No Public Access
+description: >
+  Scans synthesized CloudFormation templates in cdk.out using AWS IAM Access Analyzer
+  checkNoPublicAccess API. AWS credentials must be configured before calling this action.
+
+inputs:
+  template-dir:
+    description: Directory containing CloudFormation *.template.json files
+    default: cdk.out
+  yaml-template-dir:
+    description: >
+      Directory containing CloudFormation *.yaml/*.yml templates to convert and scan.
+      Leave empty to skip.
+    default: ""
+  fail-on-public-access:
+    description: Fail when public access is detected (set 'false' for warn-only)
+    default: "true"
+  aws-region:
+    description: AWS region for Access Analyzer API calls
+    default: us-east-1
+
+runs:
+  using: composite
+  steps:
+    - name: Install access analyzer dependencies
+      shell: bash
+      run: pip install --quiet --upgrade boto3 cfn-flip
+
+    - name: Convert CloudFormation YAML templates to JSON
+      if: inputs.yaml-template-dir != ''
+      shell: bash
+      env:
+        YAML_DIR: ${{ inputs.yaml-template-dir }}
+      run: |
+        mkdir -p cfn-yaml-out
+        find "$YAML_DIR" -maxdepth 1 \( -name "*.yaml" -o -name "*.yml" \) | while read -r f; do
+          out="cfn-yaml-out/$(basename "${f%.*}").template.json"
+          cfn-flip "$f" "$out" && echo "Converted: $f -> $out"
+        done
+
+    - name: Check no public access
+      shell: bash
+      env:
+        TEMPLATE_DIR: ${{ inputs.template-dir }}
+        YAML_TEMPLATE_DIR: ${{ inputs.yaml-template-dir != '' && 'cfn-yaml-out' || '' }}
+        FAIL_ON_PUBLIC_ACCESS: ${{ inputs.fail-on-public-access }}
+        AWS_REGION: ${{ inputs.aws-region }}
+      run: |
+        python3 << 'PYEOF'
+        import json
+        import os
+        import sys
+        from pathlib import Path
+
+        import boto3
+        from botocore.exceptions import ClientError
+
+        POLICY_MAP = {
+            "AWS::S3::BucketPolicy":               ("PolicyDocument",           "AWS::S3::Bucket"),
+            "AWS::SQS::QueuePolicy":               ("PolicyDocument",           "AWS::SQS::Queue"),
+            "AWS::SNS::TopicPolicy":               ("PolicyDocument",           "AWS::SNS::Topic"),
+            "AWS::KMS::Key":                       ("KeyPolicy",                "AWS::KMS::Key"),
+            "AWS::ECR::Repository":                ("RepositoryPolicyText",     "AWS::ECR::Repository"),
+            "AWS::SecretsManager::ResourcePolicy": ("ResourcePolicy",           "AWS::SecretsManager::Secret"),
+            # AWS::IAM::Role excluded: CDK trust policies contain intrinsic functions
+            # (Fn::Sub, Ref, Fn::If) that CheckNoPublicAccess cannot evaluate, producing
+            # misleading errors. OIDC trust policies also trigger false positives.
+        }
+
+        template_dir      = Path(os.environ["TEMPLATE_DIR"])
+        yaml_template_dir = os.environ.get("YAML_TEMPLATE_DIR", "")
+        fail_on_public    = os.environ["FAIL_ON_PUBLIC_ACCESS"].lower() == "true"
+        aws_region        = os.environ.get("AWS_REGION", "us-east-1")
+        summary_path      = os.environ.get("GITHUB_STEP_SUMMARY")
+
+        def find_templates(d):
+            skip = {"manifest.json", "tree.json"}
+            return sorted(
+                p for p in d.rglob("*.template.json")
+                if p.name not in skip and not p.name.startswith("asset.")
+            )
+
+        def extract_policies(template):
+            results = []
+            for lid, res in template.get("Resources", {}).items():
+                cf_type = res.get("Type", "")
+                if cf_type not in POLICY_MAP:
+                    continue
+                policy_prop, analyzer_type = POLICY_MAP[cf_type]
+                policy_doc = res.get("Properties", {}).get(policy_prop)
+                if policy_doc is not None:
+                    results.append((lid, analyzer_type, policy_doc))
+            return results
+
+        def check_policy(client, lid, analyzer_type, policy_doc):
+            try:
+                resp = client.check_no_public_access(
+                    policyDocument=json.dumps(policy_doc),
+                    resourceType=analyzer_type,
+                )
+                is_public = resp.get("result") == "FAIL"
+                reasons   = [r.get("description", "") for r in resp.get("reasons", [])]
+                return {"logical_id": lid, "resource_type": analyzer_type,
+                        "public": is_public, "reasons": reasons}
+            except ClientError as exc:
+                code = exc.response["Error"]["Code"]
+                msg  = exc.response["Error"]["Message"]
+                return {"logical_id": lid, "resource_type": analyzer_type,
+                        "public": False, "error": f"{code}: {msg}"}
+
+        def append_summary(findings, template_name):
+            if not summary_path:
+                return
+            with open(summary_path, "a") as f:
+                f.write(f"\n### Access Analyzer - `{template_name}`\n\n")
+                if not findings:
+                    f.write("_No applicable resources found._\n")
+                    return
+                f.write("| Resource | Type | Result |\n|---|---|---|\n")
+                for r in findings:
+                    if "error" in r:
+                        icon, status = "warning", f"Error: {r['error']}"
+                    elif r["public"]:
+                        reasons = "; ".join(r["reasons"]) if r["reasons"] else "public access detected"
+                        icon, status = "x", f"FAIL - {reasons}"
+                    else:
+                        icon, status = "check", "PASS"
+                    f.write(f"| `{r['logical_id']}` | `{r['resource_type']}` | :{icon}: {status} |\n")
+
+        def scan_dir(client, d, total_violations):
+            if not d.is_dir():
+                return total_violations
+            templates = find_templates(d)
+            if not templates:
+                print(f"::notice::No *.template.json files found in '{d}' - skipping")
+                return total_violations
+            for tpl_path in templates:
+                name = tpl_path.name
+                print(f"\n=== {name} ===")
+                try:
+                    template = json.loads(tpl_path.read_text())
+                except json.JSONDecodeError as exc:
+                    print(f"::warning::Could not parse {name}: {exc}")
+                    continue
+                policies = extract_policies(template)
+                if not policies:
+                    print("  No applicable resources found - skipping")
+                    append_summary([], name)
+                    continue
+                findings = []
+                for lid, analyzer_type, policy_doc in policies:
+                    result = check_policy(client, lid, analyzer_type, policy_doc)
+                    findings.append(result)
+                    if "error" in result:
+                        print(f"  [!] {lid} ({analyzer_type}) - error: {result['error']}")
+                    elif result["public"]:
+                        total_violations += 1
+                        reasons = "; ".join(result["reasons"]) if result["reasons"] else "public access detected"
+                        print(f"  [x] {lid} ({analyzer_type}) - FAIL: {reasons}")
+                    else:
+                        print(f"  [ok] {lid} ({analyzer_type}) - PASS")
+                append_summary(findings, name)
+            return total_violations
+
+        client           = boto3.client("accessanalyzer", region_name=aws_region)
+        total_violations = 0
+
+        total_violations = scan_dir(client, template_dir, total_violations)
+        if yaml_template_dir:
+            total_violations = scan_dir(client, Path(yaml_template_dir), total_violations)
+
+        print()
+        if total_violations > 0:
+            print(f"::error::{total_violations} resource(s) grant public access")
+            sys.exit(1 if fail_on_public else 0)
+        else:
+            print("All resources passed the no-public-access check.")
+        PYEOF
+
+    - name: Notify on public access detected
+      if: failure()
+      shell: bash
+      run: echo "::error::IAM Access Analyzer detected resources that grant public access. Review the job output for details."

--- a/.github/actions/ship-logs/action.yml
+++ b/.github/actions/ship-logs/action.yml
@@ -1,0 +1,184 @@
+name: Ship CI/CD Logs
+description: >
+  Upload workflow step logs to S3 and/or CloudWatch Logs.
+  AWS credentials must be configured before calling this action.
+
+inputs:
+  log-dir:
+    description: Directory containing *.log files and metadata.json
+    required: true
+  destination:
+    description: "Where to send logs: s3, cloudwatch, or both"
+    required: false
+    default: "s3"
+  s3-bucket:
+    description: >-
+      S3 bucket name. Composite actions cannot read the `vars` context,
+      so callers must resolve `vars.CI_LOGS_BUCKET` at the workflow level
+      and pass the result here. The S3 upload step fails if empty.
+    required: false
+    default: ""
+  s3-prefix:
+    description: S3 key prefix inside the bucket
+    required: false
+    default: "ci-logs"
+  cloudwatch-log-group:
+    description: >-
+      CloudWatch Logs log group name. Composite actions cannot read the
+      `vars` context, so callers must resolve `vars.CI_LOGS_LOG_GROUP` at
+      the workflow level and pass the result here. The CloudWatch step
+      fails if empty.
+    required: false
+    default: ""
+  aws-region:
+    description: AWS region
+    required: false
+    default: "us-east-1"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve log path variables
+      id: vars
+      shell: bash
+      env:
+        REPO: ${{ github.repository }}
+        WORKFLOW: ${{ github.workflow }}
+        RUN_ID: ${{ github.run_id }}
+        ATTEMPT: ${{ github.run_attempt }}
+        S3_PREFIX: ${{ inputs.s3-prefix }}
+      run: |
+        # Sanitise workflow name: keep only alphanumeric and hyphens
+        SAFE_WORKFLOW=$(echo "$WORKFLOW" | tr -cs 'a-zA-Z0-9-' '-' | tr '[:upper:]' '[:lower:]' | sed 's/^-//;s/-$//')
+        S3_KEY="${S3_PREFIX}/${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}"
+        CW_STREAM="${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}"
+        echo "s3-key=${S3_KEY}" >> "$GITHUB_OUTPUT"
+        echo "cw-stream=${CW_STREAM}" >> "$GITHUB_OUTPUT"
+
+    - name: Upload logs to S3
+      if: inputs.destination == 's3' || inputs.destination == 'both'
+      shell: bash
+      env:
+        LOG_DIR: ${{ inputs.log-dir }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_KEY: ${{ steps.vars.outputs.s3-key }}
+      run: |
+        set -euo pipefail
+        if [ -z "$S3_BUCKET" ]; then
+          echo "::error::ship-logs: s3-bucket input is empty. Set vars.CI_LOGS_BUCKET in the calling repo or pass ci-log-s3-bucket explicitly."
+          exit 1
+        fi
+        tar czf "${RUNNER_TEMP}/ci-logs.tar.gz" -C "$LOG_DIR" .
+        aws s3 cp "${RUNNER_TEMP}/ci-logs.tar.gz" \
+          "s3://${S3_BUCKET}/${S3_KEY}/logs.tar.gz"
+        if [ -f "${LOG_DIR}/metadata.json" ]; then
+          aws s3 cp "${LOG_DIR}/metadata.json" \
+            "s3://${S3_BUCKET}/${S3_KEY}/metadata.json"
+        fi
+        S3_URI="s3://${S3_BUCKET}/${S3_KEY}/"
+        echo "## CI Logs — S3" >> "$GITHUB_STEP_SUMMARY"
+        echo "Logs uploaded to \`${S3_URI}\`" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Send logs to CloudWatch
+      if: inputs.destination == 'cloudwatch' || inputs.destination == 'both'
+      shell: bash
+      env:
+        LOG_DIR: ${{ inputs.log-dir }}
+        LOG_GROUP: ${{ inputs.cloudwatch-log-group }}
+        LOG_STREAM: ${{ steps.vars.outputs.cw-stream }}
+        AWS_REGION: ${{ inputs.aws-region }}
+      run: |
+        set -euo pipefail
+        if [ -z "$LOG_GROUP" ]; then
+          echo "::error::ship-logs: cloudwatch-log-group input is empty. Set vars.CI_LOGS_LOG_GROUP in the calling repo or pass ci-log-cloudwatch-group explicitly."
+          exit 1
+        fi
+        # Create log group (ignore if exists) with 90-day retention
+        aws logs create-log-group \
+          --log-group-name "$LOG_GROUP" \
+          --region "$AWS_REGION" 2>/dev/null || true
+        aws logs put-retention-policy \
+          --log-group-name "$LOG_GROUP" \
+          --retention-in-days 90 \
+          --region "$AWS_REGION" 2>/dev/null || true
+        # Create log stream (ignore if exists on retry)
+        aws logs create-log-stream \
+          --log-group-name "$LOG_GROUP" \
+          --log-stream-name "$LOG_STREAM" \
+          --region "$AWS_REGION" 2>/dev/null || true
+
+        # Build all events in a single Python invocation and upload via file
+        python3 << 'PYEOF'
+        import json
+        import os
+        import subprocess
+        import sys
+        import time
+        from pathlib import Path
+
+        log_dir    = Path(os.environ["LOG_DIR"])
+        log_group  = os.environ["LOG_GROUP"]
+        log_stream = os.environ["LOG_STREAM"]
+        region     = os.environ["AWS_REGION"]
+
+        sequence_token = None
+
+        def put_events(events):
+            """Send a batch of events to CloudWatch, returning the next sequence token."""
+            global sequence_token
+            if not events:
+                return
+            events_file = Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "cw-events.json"
+            events_file.write_text(json.dumps(events))
+            cmd = [
+                "aws", "logs", "put-log-events",
+                "--log-group-name", log_group,
+                "--log-stream-name", log_stream,
+                "--log-events", f"file://{events_file}",
+                "--region", region,
+            ]
+            if sequence_token:
+                cmd += ["--sequence-token", sequence_token]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode == 0:
+                try:
+                    sequence_token = json.loads(result.stdout).get("nextSequenceToken")
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+            else:
+                print(f"Warning: put-log-events failed: {result.stderr.strip()}", file=sys.stderr)
+
+        # Process each log file
+        for logfile in sorted(log_dir.glob("*.log")):
+            lines = logfile.read_text(errors="replace").splitlines()
+            if not lines:
+                continue
+            basename = logfile.name
+            ts_ms = int(time.time() * 1000)
+            # CloudWatch limit: 10,000 events / 1MB per put-log-events call
+            batch = []
+            batch_size = 0
+            for i, line in enumerate(lines):
+                message = f"[{basename}] {line}"
+                event = {"timestamp": ts_ms + i, "message": message}
+                event_size = len(json.dumps(event)) + 26  # overhead per event
+                if len(batch) >= 9000 or batch_size + event_size > 900_000:
+                    put_events(batch)
+                    batch = []
+                    batch_size = 0
+                batch.append(event)
+                batch_size += event_size
+            put_events(batch)
+
+        # Send metadata.json as a single event
+        metadata_path = log_dir / "metadata.json"
+        if metadata_path.exists():
+            meta_content = metadata_path.read_text(errors="replace")
+            put_events([{
+                "timestamp": int(time.time() * 1000),
+                "message": meta_content,
+            }])
+        PYEOF
+        echo "## CI Logs — CloudWatch" >> "$GITHUB_STEP_SUMMARY"
+        echo "Log group: \`${LOG_GROUP}\`  " >> "$GITHUB_STEP_SUMMARY"
+        echo "Log stream: \`${LOG_STREAM}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/access-analyzer-check.yml
+++ b/.github/workflows/access-analyzer-check.yml
@@ -1,0 +1,63 @@
+name: IAM Access Analyzer — No Public Access
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        description: AWS region for Access Analyzer API calls
+        type: string
+        default: us-east-1
+      template-dir:
+        description: Directory containing CloudFormation *.template.json files (e.g. cdk.out)
+        type: string
+        default: cdk.out
+      yaml-template-dir:
+        description: >-
+          Directory containing CloudFormation *.yaml/*.yml templates to scan.
+          Templates are converted to JSON via cfn-flip before scanning.
+          Leave empty to skip YAML conversion (default).
+        type: string
+        default: ""
+      fail-on-public-access:
+        description: Fail the job when public access is detected (set false for warn-only)
+        type: boolean
+        default: true
+      environment:
+        description: >-
+          GitHub environment to deploy into. The environment must have an AWS_ROLE_ARN
+          secret set to the IAM role ARN to assume via OIDC.
+        type: string
+        default: production
+
+permissions:
+  id-token: write  # OIDC token for AWS authentication
+  contents: read
+
+jobs:
+  check-no-public-access:
+    name: Check No Public Access
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check no public access
+        uses: Specter099/.github/.github/actions/access-analyzer@main
+        with:
+          template-dir: ${{ inputs.template-dir }}
+          yaml-template-dir: ${{ inputs.yaml-template-dir }}
+          fail-on-public-access: ${{ inputs.fail-on-public-access }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,57 @@
+name: Backup to S3
+
+on:
+  schedule:
+    - cron: "0 2 * * 0"  # weekly, Sunday 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  backup:
+    name: Backup to S3
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve inputs
+        id: vars
+        run: |
+          REPO_NAME="${{ github.event.repository.name }}"
+          DATE=$(date -u +%Y-%m-%d)
+          SHA="${{ github.sha }}"
+          FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+          echo "s3-key=${REPO_NAME}/${FILENAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Create zip archive
+        run: |
+          git archive --format=zip --output="${{ steps.vars.outputs.filename }}" HEAD
+          SIZE=$(du -sh "${{ steps.vars.outputs.filename }}" | cut -f1)
+          echo "ARCHIVE_SIZE=$SIZE" >> "$GITHUB_ENV"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp "${{ steps.vars.outputs.filename }}" \
+            "s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}"
+
+      - name: Write job summary
+        run: |
+          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| S3 URI | \`s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -1,0 +1,189 @@
+name: CDK Deploy
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        description: AWS region to deploy to
+        type: string
+        default: "us-east-1"
+      cdk-version:
+        description: >-
+          CDK CLI npm version. Empty/unset falls back to
+          `vars.CDK_CLI_VERSION` in the calling repo, then to the
+          hardcoded default in the setup-cdk action.
+        type: string
+        default: ""
+      stacks:
+        description: Stack name(s) to deploy, or '--all' for all stacks
+        type: string
+        default: "--all"
+      environment:
+        description: GitHub environment to use (controls which secrets/vars are loaded)
+        type: string
+        default: "production"
+      smoke-test-url:
+        description: URL to curl after deploy for smoke test (optional)
+        type: string
+        default: ""
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: true
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "both"
+      ci-log-s3-bucket:
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
+        type: string
+        default: ""
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
+
+      - name: Setup CDK
+        uses: Specter099/.github/.github/actions/setup-cdk@main
+        with:
+          cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
+
+      - name: Capture setup versions
+        if: ${{ inputs.enable-ci-logs }}
+        run: |
+          {
+            echo "=== Setup Versions ==="
+            echo "node: $(node --version)"
+            echo "npm:  $(npm --version)"
+            echo "cdk:  $(cdk --version)"
+            echo "python3: $(python3 --version)"
+            echo "pip3:    $(pip3 --version)"
+            echo "aws-cli: $(aws --version 2>&1)"
+          } | tee "$RUNNER_TEMP/ci-logs/setup-versions.log"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: CDK Deploy
+        env:
+          CDK_STACKS: ${{ inputs.stacks }}
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            cdk deploy $CDK_STACKS --require-approval never --verbose --outputs-file outputs.json 2>&1 \
+              | awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' \
+              | tee "$RUNNER_TEMP/ci-logs/cdk-deploy.log"
+          else
+            cdk deploy $CDK_STACKS --require-approval never --verbose --outputs-file outputs.json
+          fi
+
+      - name: Upload stack outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stack-outputs-${{ inputs.environment }}
+          path: outputs.json
+          if-no-files-found: ignore
+
+      - name: Write outputs to job summary
+        if: always()
+        run: |
+          if [ -f outputs.json ]; then
+            echo "## Stack Outputs" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat outputs.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No stack outputs file found." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Smoke test
+        if: ${{ inputs.smoke-test-url != '' }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          _run_smoke() {
+            status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
+              "${{ inputs.smoke-test-url }}" || echo "000")
+            echo "Smoke test HTTP status: $status"
+            echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
+            echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
+            if [[ "$status" == "000" ]]; then
+              echo "::warning::Smoke test: curl failed or timed out"
+            else
+              echo "Smoke test passed — endpoint is reachable."
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_smoke 2>&1 \
+              | awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' \
+              | tee "$RUNNER_TEMP/ci-logs/smoke-test.log"
+          else
+            _run_smoke
+          fi
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
+        run: |
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+          }
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -1,0 +1,287 @@
+---
+name: CDK Review
+
+"on":
+  workflow_call:
+    inputs:
+      aws-region:
+        description: AWS region to deploy to
+        type: string
+        default: "us-east-1"
+      cdk-version:
+        description: >-
+          CDK CLI npm version. Empty/unset falls back to
+          `vars.CDK_CLI_VERSION` in the calling repo, then to the
+          hardcoded default in the setup-cdk action.
+        type: string
+        default: ""
+      smoke-test-url:
+        description: URL to curl after deploy (optional)
+        type: string
+        default: ""
+      enable-access-analyzer:
+        description: >-
+          Run IAM Access Analyzer CheckNoPublicAccess against synthesized
+          templates (requires AWS_ROLE_ARN).
+        type: boolean
+        default: true
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: true
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "both"
+      ci-log-s3-bucket:
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
+        type: string
+        default: ""
+    secrets:
+      AWS_ROLE_ARN:
+        description: >-
+          IAM role ARN for OIDC federation
+          (optional — skips synth/diff if absent)
+        required: false
+jobs:
+  review:
+    name: Synth & Diff
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    env:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
+
+      - name: Setup CDK
+        uses: Specter099/.github/.github/actions/setup-cdk@main
+        with:
+          cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
+
+      - name: Lint (ruff)
+        if: hashFiles('requirements-dev.txt') != '' && success()
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          _run_lint() {
+            if command -v ruff &> /dev/null; then
+              ruff check .
+            else
+              echo "::notice::ruff not installed — skipping lint"
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_lint 2>&1 | tee "$RUNNER_TEMP/ci-logs/ruff-check.log"
+          else
+            _run_lint
+          fi
+
+      - name: Unit tests
+        if: hashFiles('tests/') != '' && success()
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          _run_tests() {
+            if command -v pytest &> /dev/null; then
+              pytest tests/ -v || rc=$?
+              if [ "${rc:-0}" -eq 5 ]; then
+                echo "::notice::no tests collected — skipping"
+              elif [ "${rc:-0}" -ne 0 ]; then
+                exit "$rc"
+              fi
+            else
+              echo "::notice::pytest not installed — skipping tests"
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_tests 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest.log"
+          else
+            _run_tests
+          fi
+
+      - name: Dependency audit
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          _run_audit() {
+            if command -v pip-audit &> /dev/null; then
+              pip-audit -r requirements.txt
+            else
+              echo "::notice::pip-audit not installed — skipping audit"
+            fi
+          }
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            _run_audit 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
+          else
+            _run_audit
+          fi
+
+      - name: Configure AWS credentials
+        if: env.AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: CDK Synth
+        if: env.AWS_ROLE_ARN != ''
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            cdk synth 2>&1 | tee "$RUNNER_TEMP/ci-logs/cdk-synth.log"
+          else
+            cdk synth
+          fi
+
+      - name: IAM Access Analyzer — no public access
+        if: env.AWS_ROLE_ARN != '' && inputs.enable-access-analyzer
+        uses: Specter099/.github/.github/actions/access-analyzer@main
+        with:
+          template-dir: cdk.out
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: SAST scan (bandit)
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          pip install bandit
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            bandit -r . -ll --exclude ./.venv,./cdk.out,./lambda_layer 2>&1 | tee "$RUNNER_TEMP/ci-logs/bandit.log"
+          else
+            bandit -r . -ll --exclude ./.venv,./cdk.out,./lambda_layer
+          fi
+
+      - name: CDK Nag (informational)
+        if: env.AWS_ROLE_ARN != ''
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" | tee "$RUNNER_TEMP/ci-logs/cdk-nag.log" || true
+          else
+            CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" || true
+          fi
+
+      - name: CDK Diff
+        if: env.AWS_ROLE_ARN != ''
+        id: diff
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          diff_output=$(cdk diff 2>&1) || true
+          echo "$diff_output"
+          {
+            echo "diff<<EOF"
+            echo "$diff_output"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            echo "$diff_output" > "$RUNNER_TEMP/ci-logs/cdk-diff.log"
+          fi
+
+      - name: Comment diff on PR
+        if: env.AWS_ROLE_ARN != ''
+        uses: actions/github-script@v7
+        env:
+          DIFF: ${{ steps.diff.outputs.diff }}
+        with:
+          script: |
+            const diff = process.env.DIFF;
+            const body = `### CDK Diff\n\n\`\`\`\n${diff}\n\`\`\``;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.startsWith('### CDK Diff')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: AWS credentials not configured
+        if: env.AWS_ROLE_ARN == ''
+        run: echo "::warning::AWS_ROLE_ARN secret not set — skipping synth/diff"
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
+        run: |
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+          }
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs && env.AWS_ROLE_ARN != ''
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,21 @@
+name: Gitleaks
+
+on:
+  workflow_call:
+
+jobs:
+  gitleaks:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,260 @@
+---
+name: Python CI
+# Requires callers to include ruff and pytest in their requirements file.
+# Install via requirements-path (default) or override with install-command.
+#
+# Callers should set concurrency at the workflow level:
+#   concurrency:
+#     group: python-ci-${{ github.ref }}
+#     cancel-in-progress: true
+
+"on":
+  workflow_call:
+    inputs:
+      python-versions:
+        description: >-
+          JSON array of Python versions for matrix
+          (e.g. '["3.11","3.12"]')
+        type: string
+        default: '["3.12"]'
+      requirements-path:
+        description: >-
+          Path to dev requirements file
+          (ignored if install-command is set)
+        type: string
+        default: "requirements-dev.txt"
+      install-command:
+        description: Custom install command (overrides requirements-path)
+        type: string
+        default: ""
+      tests-dir:
+        description: Directory to run pytest against
+        type: string
+        default: "tests/"
+      coverage:
+        description: Enable pytest-cov coverage reporting
+        type: boolean
+        default: false
+      coverage-threshold:
+        description: >-
+          Minimum coverage percentage
+          (only used when coverage is true)
+        type: number
+        default: 80
+      pip-audit:
+        description: Run pip-audit dependency vulnerability scan
+        type: boolean
+        default: false
+      bandit:
+        description: Run bandit SAST scan (medium+ severity)
+        type: boolean
+        default: false
+      enable-ci-logs:
+        description: Ship detailed step logs to S3/CloudWatch
+        type: boolean
+        default: true
+      ci-log-destination:
+        description: "Log destination: s3, cloudwatch, or both"
+        type: string
+        default: "both"
+      ci-log-s3-bucket:
+        description: >-
+          S3 bucket for CI logs. Empty/unset falls back to
+          `vars.CI_LOGS_BUCKET` in the calling repo. Required when
+          ci-log-destination includes 's3'.
+        type: string
+        default: ""
+      ci-log-cloudwatch-group:
+        description: >-
+          CloudWatch Logs group name. Empty/unset falls back to
+          `vars.CI_LOGS_LOG_GROUP` in the calling repo. Required when
+          ci-log-destination includes 'cloudwatch'.
+        type: string
+        default: ""
+      aws-region:
+        description: AWS region (used for CI log shipping)
+        type: string
+        default: "us-east-1"
+    secrets:
+      AWS_ROLE_ARN:
+        description: >-
+          IAM role ARN for OIDC federation (required when enable-ci-logs is true)
+        required: false
+
+jobs:
+  ci:
+    name: "Lint, Secrets & Test (py${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    permissions:
+      # id-token: write is needed for OIDC when enable-ci-logs is true.
+      # The OIDC credential step itself is gated behind enable-ci-logs.
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(inputs.python-versions) }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0  # full history required by gitleaks
+
+      - name: Init CI log directory
+        if: ${{ inputs.enable-ci-logs }}
+        run: mkdir -p "$RUNNER_TEMP/ci-logs"
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
+      - name: Install dev dependencies
+        env:
+          INSTALL_COMMAND: ${{ inputs.install-command }}
+          REQUIREMENTS_PATH: ${{ inputs.requirements-path }}
+        run: |
+          if [ -n "$INSTALL_COMMAND" ]; then
+            eval "$INSTALL_COMMAND"
+          else
+            pip install -r "$REQUIREMENTS_PATH"
+          fi
+
+      - name: Lint (ruff)
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            ruff check . 2>&1 | tee "$RUNNER_TEMP/ci-logs/ruff-check.log"
+          else
+            ruff check .
+          fi
+
+      - name: Format check (ruff)
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            ruff format --check . 2>&1 | tee "$RUNNER_TEMP/ci-logs/ruff-format.log"
+          else
+            ruff format --check .
+          fi
+
+      - name: Secrets scan (gitleaks)
+        uses: gitleaks/gitleaks-action@f586c14365d4643c6aa59d472ae6e984bf47bb34  # v2.3.8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dependency audit (pip-audit)
+        if: ${{ inputs.pip-audit }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          pip install pip-audit
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pip-audit 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
+          else
+            pip-audit
+          fi
+
+      - name: SAST scan (bandit)
+        if: ${{ inputs.bandit }}
+        env:
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          pip install bandit
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            bandit -r . -ll --exclude .venv,cdk.out 2>&1 | tee "$RUNNER_TEMP/ci-logs/bandit.log"
+          else
+            bandit -r . -ll --exclude .venv,cdk.out
+          fi
+
+      - name: Unit tests (pytest)
+        if: ${{ !inputs.coverage }}
+        env:
+          TESTS_DIR: ${{ inputs.tests-dir }}
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pytest "$TESTS_DIR" -v 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest.log"
+          else
+            pytest "$TESTS_DIR" -v
+          fi
+
+      - name: Unit tests with coverage (pytest-cov)
+        if: ${{ inputs.coverage }}
+        env:
+          TESTS_DIR: ${{ inputs.tests-dir }}
+          COV_THRESHOLD: ${{ inputs.coverage-threshold }}
+          ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
+        run: |
+          set -o pipefail
+          pip install pytest-cov
+          if [ "$ENABLE_LOGS" = "true" ]; then
+            pytest "$TESTS_DIR" -v \
+              --cov \
+              --cov-report=term-missing \
+              --cov-fail-under="$COV_THRESHOLD" 2>&1 | tee "$RUNNER_TEMP/ci-logs/pytest-cov.log"
+          else
+            pytest "$TESTS_DIR" -v \
+              --cov \
+              --cov-report=term-missing \
+              --cov-fail-under="$COV_THRESHOLD"
+          fi
+
+      - name: Configure AWS credentials for logging
+        if: always() && inputs.enable-ci-logs
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Generate log metadata
+        if: always() && inputs.enable-ci-logs
+        env:
+          META_REPOSITORY: ${{ github.repository }}
+          META_WORKFLOW: ${{ github.workflow }}
+          META_RUN_ID: ${{ github.run_id }}
+          META_RUN_ATTEMPT: ${{ github.run_attempt }}
+          META_REF: ${{ github.ref }}
+          META_SHA: ${{ github.sha }}
+          META_ACTOR: ${{ github.actor }}
+          META_EVENT: ${{ github.event_name }}
+          META_JOB_STATUS: ${{ job.status }}
+        run: |
+          python3 -c "
+          import json, os, datetime
+          meta = {
+              'repository': os.environ['META_REPOSITORY'],
+              'workflow': os.environ['META_WORKFLOW'],
+              'run_id': os.environ['META_RUN_ID'],
+              'run_attempt': os.environ['META_RUN_ATTEMPT'],
+              'ref': os.environ['META_REF'],
+              'sha': os.environ['META_SHA'],
+              'actor': os.environ['META_ACTOR'],
+              'event': os.environ['META_EVENT'],
+              'job_status': os.environ['META_JOB_STATUS'],
+              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+          }
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
+              json.dump(meta, f, indent=2)
+          "
+
+      - name: Ship CI logs
+        if: always() && inputs.enable-ci-logs
+        uses: Specter099/.github/.github/actions/ship-logs@main
+        with:
+          log-dir: ${{ runner.temp }}/ci-logs
+          destination: ${{ inputs.ci-log-destination }}
+          s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
+          cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
+          aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -1,0 +1,95 @@
+name: Repo Backup to S3
+
+on:
+  workflow_call:
+    inputs:
+      s3-bucket:
+        description: S3 bucket name to upload the backup to
+        type: string
+        required: true
+      s3-prefix:
+        description: Key prefix (folder) within the bucket (defaults to repo name)
+        type: string
+        default: ""
+      aws-region:
+        description: AWS region of the S3 bucket
+        type: string
+        default: "us-east-1"
+      environment:
+        description: GitHub environment whose secrets contain AWS_ROLE_ARN
+        type: string
+        default: "backup"
+  workflow_dispatch:
+    inputs:
+      s3-bucket:
+        description: S3 bucket name to upload the backup to
+        type: string
+        required: true
+      s3-prefix:
+        description: Key prefix (folder) within the bucket (defaults to repo name)
+        type: string
+        default: ""
+      aws-region:
+        description: AWS region of the S3 bucket
+        type: string
+        default: "us-east-1"
+      environment:
+        description: GitHub environment whose secrets contain AWS_ROLE_ARN
+        type: string
+        default: "backup"
+
+jobs:
+  backup:
+    name: Backup to S3
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve inputs
+        id: vars
+        run: |
+          REPO_NAME="${{ github.event.repository.name }}"
+          PREFIX="${{ inputs.s3-prefix }}"
+          if [ -z "$PREFIX" ]; then
+            PREFIX="$REPO_NAME"
+          fi
+          DATE=$(date -u +%Y-%m-%d)
+          SHA="${{ github.sha }}"
+          FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
+          echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+          echo "s3-key=${PREFIX}/${FILENAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Create zip archive
+        run: |
+          git archive --format=zip --output="${{ steps.vars.outputs.filename }}" HEAD
+          SIZE=$(du -sh "${{ steps.vars.outputs.filename }}" | cut -f1)
+          echo "ARCHIVE_SIZE=$SIZE" >> "$GITHUB_ENV"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp "${{ steps.vars.outputs.filename }}" \
+            "s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}"
+
+      - name: Write job summary
+        run: |
+          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| S3 URI | \`s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-bucket-names.yml
+++ b/.github/workflows/validate-bucket-names.yml
@@ -1,0 +1,85 @@
+name: Validate S3 Bucket Names
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to use
+        type: string
+        default: "3.12"
+      scan-path:
+        description: Directory to scan for bucket names
+        type: string
+        default: "."
+      template-dir:
+        description: >
+          Directory containing synthesized CloudFormation *.template.json files
+          (e.g. cdk.out). When provided, scans templates instead of (or in
+          addition to) Python source. Omit to use Python source scan only.
+        type: string
+        default: ""
+
+jobs:
+  validate-bucket-names:
+    name: S3 Bucket Naming Convention
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v4
+
+      - name: Checkout .github repo (for shared scripts)
+        uses: actions/checkout@v4
+        with:
+          repository: Specter099/.github
+          path: .shared-github
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Validate S3 bucket names
+        id: validate
+        env:
+          SCAN_PATH: ${{ inputs.scan-path }}
+          TEMPLATE_DIR: ${{ inputs.template-dir }}
+        run: |
+          args=()
+          [ -n "$SCAN_PATH" ]    && args+=(--path "$SCAN_PATH")
+          [ -n "$TEMPLATE_DIR" ] && args+=(--template-dir "$TEMPLATE_DIR")
+          python .shared-github/scripts/validate_bucket_names.py "${args[@]}"
+
+      - name: Comment on PR (violations only)
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `### S3 Bucket Naming Violations
+
+            One or more S3 \`bucket_name=\` values in this PR do not conform
+            to the required convention:
+
+            \`\`\`
+            {prefix}-{12-digit-account-id}-{aws-region}-an
+            \`\`\`
+
+            **Example:** \`bitwarden-logs-123456789012-us-east-1-an\`
+
+            Run the script locally to see exactly which files and lines need
+            to be updated:
+
+            \`\`\`bash
+            python scripts/validate_bucket_names.py --path .
+            \`\`\`
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+---
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  truthy:
+    allowed-values: ["true", "false", "on"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Shared GitHub Actions reusable workflows and composite actions for the Specter099 org. Provides standardized CI/CD pipelines for CDK projects, static sites (frontend + CDK infra), pure Python libraries, repo backups to S3, secret scanning, IAM Access Analyzer checks, and S3 bucket naming convention enforcement. Consumed by caller repos via `uses: Specter099/.github/.github/workflows/<name>@main`.
+
+## Common Commands
+
+# Lint all YAML files
+yamllint -c .yamllint.yml .github/
+
+# Validate bucket naming script locally
+python scripts/validate_bucket_names.py --path /path/to/cdk/project
+
+# Run access analyzer check locally (requires AWS credentials)
+python scripts/check_no_public_access.py --template-dir /path/to/cdk.out
+
+## Directory Structure
+
+.github/
+  workflows/
+    cdk-review.yml            # PR check: lint, test, synth, diff, SAST, IaC scan
+    cdk-deploy.yml            # Deploy CDK stacks to production
+    static-site-review.yml    # PR check: frontend + CDK infra
+    static-site-deploy.yml    # Build frontend + deploy CDK
+    python-ci.yml             # Lint (ruff), format, gitleaks, pytest
+    repo-backup.yml           # Archive repo to S3 (reusable)
+    backup.yml                # Weekly self-backup (schedule: Sunday 02:00 UTC)
+    access-analyzer-check.yml # IAM Access Analyzer public access check
+    validate-bucket-names.yml # S3 bucket naming convention enforcement
+    gitleaks.yml              # Secret scan (reusable wrapper)
+  actions/
+    setup-cdk/action.yml      # Composite: Python 3.12 + Node 22 + CDK CLI
+    access-analyzer/action.yml # Composite: scan CFN templates for public access
+scripts/
+  check_no_public_access.py   # CLI for IAM Access Analyzer CheckNoPublicAccess API
+  validate_bucket_names.py    # AST-based S3 bucket_name= convention checker
+
+## Architecture
+
+All workflows use `workflow_call` triggers — caller repos reference them with `uses:` and pass inputs. AWS authentication is OIDC-based: callers must have an `AWS_ROLE_ARN` secret on their GitHub environment (default: `production`).
+
+**Workflow dependency chain:**
+- `cdk-review` and `cdk-deploy` both use the `setup-cdk` composite action
+- `static-site-review` and `static-site-deploy` extend CDK workflows with frontend (npm) build/test steps
+- `cdk-review` includes SAST (bandit), IaC scanning (checkov), and CDK Nag in addition to synth/diff
+- `python-ci` is standalone (no AWS credentials needed) — runs ruff, gitleaks, and pytest
+
+**Trigger convention in caller repos:**
+- All checks (review, security, tests, bucket-name validation) MUST trigger on `pull_request: [main]` only.
+- `push: [main]` is reserved for deploy workflows (and scheduled backups).
+- A caller workflow must never trigger on both `pull_request` and `push: [main]` — that double-runs the same checks at merge. Merge protection covers main-branch correctness; PR checks are the gate.
+
+**PR diff commenting:** `cdk-review` and `static-site-review` post CDK diff output as a PR comment, updating in place on re-runs.
+
+**Bucket naming convention:** `{prefix}-{12-digit-account-id}-{aws-region}-an`. The `validate-bucket-names` workflow checks both Python source (AST parsing for `bucket_name=` kwargs) and synthesized CloudFormation templates.
+
+## Configuration
+
+| Secret/Variable | Scope | Purpose |
+|---|---|---|
+| `AWS_ROLE_ARN` | Environment secret | IAM role ARN for OIDC federation (all AWS workflows) |
+| `BACKUP_S3_BUCKET` | Environment variable | S3 bucket for repo backups (`backup.yml`) |
+
+## Code Style
+
+- YAML: `.yamllint.yml` config — line-length disabled, document-start disabled, truthy allows `on`
+- Python scripts: no formatter config in repo — follow existing style (type hints, argparse CLI, boto3)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,215 @@
+# Specter099 Shared GitHub Actions
+
+Reusable workflows and composite actions for CDK projects.
+
+## Quick Reference
+
+| Name | Type | Use When |
+|------|------|----------|
+| `cdk-review` | Workflow | PR check for a CDK-only project |
+| `cdk-deploy` | Workflow | Deploy CDK-only project to prod |
+| `static-site-review` | Workflow | PR check for frontend + CDK project |
+| `static-site-deploy` | Workflow | Deploy frontend + CDK project to prod |
+| `repo-backup` | Workflow | Back up repo zip to S3 |
+| `python-ci` | Workflow | PR check for any pure Python project |
+| `setup-cdk` | Action | Composite action — install Python/Node/CDK |
+
+> **Required secret:** All workflows assume `AWS_ROLE_ARN` is set on the calling repo's `production` environment (or the environment passed via `environment` input).
+
+---
+
+## CDK Workflows
+
+### `cdk-review`
+
+Lints, unit tests, and dependency-audits a CDK Python project, then runs `cdk synth` + `cdk diff` and posts the diff as a PR comment (updates in place on re-run).
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `aws-region` | no | `us-east-1` | AWS region |
+| `cdk-version` | no | `2.1106.1` | CDK CLI version |
+| `smoke-test-url` | no | `""` | Unused — accepted for interface parity with deploy |
+
+**Usage**
+
+```yaml
+jobs:
+  review:
+    uses: Specter099/.github/.github/workflows/cdk-review.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1          # optional
+      cdk-version: "2.1106.1"        # optional
+```
+
+---
+
+### `cdk-deploy`
+
+Deploys a CDK Python project to the `production` environment with `--require-approval never`. Uploads `outputs.json` as an artifact and writes stack outputs to the job summary. Optionally curls a URL for a smoke test.
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `aws-region` | no | `us-east-1` | AWS region |
+| `cdk-version` | no | `2.1106.1` | CDK CLI version |
+| `smoke-test-url` | no | `""` | URL to curl after deploy |
+
+**Usage**
+
+```yaml
+jobs:
+  deploy:
+    uses: Specter099/.github/.github/workflows/cdk-deploy.yml@main
+    secrets: inherit
+    with:
+      smoke-test-url: https://example.com   # optional
+```
+
+---
+
+## Static Site Workflows
+
+### `static-site-review`
+
+PR check for a monorepo with a frontend (npm) and a CDK infra directory. Lints and tests both, builds the frontend, then synths and diffs CDK and posts the diff as a PR comment.
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `frontend-dir` | **yes** | — | Path to dir containing `package.json` |
+| `infra-dir` | **yes** | — | Path to dir containing `app.py` |
+| `aws-region` | no | `us-east-1` | AWS region |
+| `cdk-version` | no | `2.1106.1` | CDK CLI version |
+| `skip-frontend-tests` | no | `false` | Skip `npm run test` (for repos without tests) |
+
+**Usage**
+
+```yaml
+jobs:
+  review:
+    uses: Specter099/.github/.github/workflows/static-site-review.yml@main
+    secrets: inherit
+    with:
+      frontend-dir: frontend
+      infra-dir: infra
+      skip-frontend-tests: false     # optional
+```
+
+---
+
+### `static-site-deploy`
+
+Builds the frontend with `npm run build`, then deploys CDK to the `production` environment. Uploads stack outputs as an artifact and optionally runs a smoke test.
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `frontend-dir` | **yes** | — | Path to dir containing `package.json` |
+| `infra-dir` | **yes** | — | Path to dir containing `app.py` |
+| `aws-region` | no | `us-east-1` | AWS region |
+| `cdk-version` | no | `2.1106.1` | CDK CLI version |
+| `smoke-test-url` | no | `""` | URL to curl after deploy |
+
+**Usage**
+
+```yaml
+jobs:
+  deploy:
+    uses: Specter099/.github/.github/workflows/static-site-deploy.yml@main
+    secrets: inherit
+    with:
+      frontend-dir: frontend
+      infra-dir: infra
+      smoke-test-url: https://example.com   # optional
+```
+
+---
+
+## Utilities
+
+### `repo-backup`
+
+Archives the repo at HEAD with `git archive`, uploads a timestamped zip (`<repo>-YYYY-MM-DD-<sha7>.zip`) to S3, and writes backup details to the job summary. Supports `workflow_call` and `workflow_dispatch`.
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `s3-bucket` | **yes** | — | S3 bucket name |
+| `s3-prefix` | no | repo name | Key prefix (folder) within the bucket |
+| `aws-region` | no | `us-east-1` | AWS region of the bucket |
+| `environment` | no | `production` | GitHub environment with `AWS_ROLE_ARN` secret |
+
+**Usage**
+
+```yaml
+jobs:
+  backup:
+    uses: Specter099/.github/.github/workflows/repo-backup.yml@main
+    secrets: inherit
+    with:
+      s3-bucket: my-backups-bucket
+      s3-prefix: my-repo              # optional, defaults to repo name
+```
+
+---
+
+## Python CI
+
+### `python-ci`
+
+Lints, format-checks, and secret-scans a pure Python project, then runs pytest. No AWS credentials required.
+
+> **Requires:** `ruff` and `pytest` must be present in the caller's requirements file.
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `python-version` | no | `"3.12"` | Python version |
+| `requirements-path` | no | `"requirements-dev.txt"` | Path to dev requirements file |
+| `tests-dir` | no | `"tests/"` | Directory passed to pytest |
+
+**Usage**
+
+```yaml
+jobs:
+  ci:
+    uses: Specter099/.github/.github/workflows/python-ci.yml@main
+    with:
+      python-version: "3.12"                   # optional
+      requirements-path: requirements-dev.txt  # optional
+      tests-dir: tests/                        # optional
+```
+
+> **Note:** gitleaks scans the full git history. `GITHUB_TOKEN` is injected automatically by GitHub Actions — no secrets configuration needed.
+
+---
+
+## Composite Actions
+
+### `setup-cdk`
+
+Installs Python 3.12, Node 22, a pinned CDK CLI version globally, and Python dependencies from a requirements file. Used internally by all workflows above; can also be referenced directly.
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `cdk-version` | no | `2.1106.1` | CDK CLI npm version |
+| `requirements-path` | no | `requirements.txt` | Path to `requirements.txt` relative to repo root |
+
+**Usage**
+
+```yaml
+- uses: Specter099/.github/.github/actions/setup-cdk@main
+  with:
+    cdk-version: "2.1106.1"
+    requirements-path: infra/requirements.txt
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,134 @@
+# Workflow Review — Remaining Work
+
+Tracks follow-up work from the April 2026 GitHub Actions review. PRs [#45](https://github.com/Specter099/.github/pull/45) (script-injection fix) and [#46](https://github.com/Specter099/.github/pull/46) (Access Analyzer dedupe) already in flight. Everything below is scoped as a separate PR unless noted.
+
+Mental model: **all checks in CI (review workflows), CD only deploys.** Do not add check steps to `cdk-deploy.yml` or `static-site-deploy.yml`.
+
+Trigger convention in caller repos:
+- All checks (tests, security scans, lint, synth/diff, access analyzer, bucket-name validation) MUST run on `pull_request: [main]` only.
+- `push: [main]` is reserved for deploy workflows.
+- Never run a check workflow on both `pull_request` and `push: main` — that double-runs the same checks on merge.
+
+---
+
+## P0 — Security & Correctness
+
+### Fix caller-repo `security.yml` triggers
+**Files (external repos):**
+- `Specter099/static-site-infra/.github/workflows/security.yml`
+- `Specter099/bitwarden-cdk/.github/workflows/security.yml`
+- `Specter099/route53-cdk/.github/workflows/security.yml`
+
+All three trigger on both `push: [main]` **and** `pull_request: [main]`. Per the trigger convention, security scans belong to PR flow only. Remove the `push:` block from each.
+
+### Pin all actions to full SHA + add Dependabot
+**Files:** every workflow + `actions/*/action.yml`
+- Replace `@v4`, `@v7`, `@v2`, and internal `@main` refs with 40-char commit SHAs and a trailing `# vX.Y.Z` comment.
+- Especially `Specter099/.github/.github/actions/{setup-cdk,access-analyzer,ship-logs}@main` — `@main` means any commit immediately propagates to every caller.
+- Add `.github/dependabot.yml` with `package-ecosystem: github-actions` to auto-PR SHA bumps weekly.
+- `python-ci.yml` already pins `actions/checkout`, `actions/setup-python`, and `gitleaks-action` by SHA — use as reference.
+
+### Fix CDK Nag silent failure
+**File:** [`cdk-review.yml:173-183`](.github/workflows/cdk-review.yml)
+- `CDK_NAG=true cdk synth 2>&1 | grep … || true` swallows both `cdk synth` errors and grep's exit-1 on "no Nag findings".
+- Fix: run `cdk synth` once (fail on error), capture output, then `grep … || true` on the captured file.
+
+### Validate `CDK_STACKS` input in `cdk-deploy.yml`
+**File:** [`cdk-deploy.yml:82-93`](.github/workflows/cdk-deploy.yml)
+- `$CDK_STACKS` is passed unquoted to `cdk deploy` to allow `--all` or multiple stack names. Caller-controlled.
+- Add a regex guard before exec: `[[ "$CDK_STACKS" =~ ^(--all|[A-Za-z0-9_\-]+( [A-Za-z0-9_\-]+)*)$ ]] || { echo "::error::invalid stacks input"; exit 1; }`
+
+---
+
+## P1 — Reliability & Hygiene
+
+### Add `timeout-minutes` to every job
+**Files:** all workflows
+- Default is 6 hours — a hung step burns runner budget.
+- Reviews: `timeout-minutes: 15`. Deploys: `timeout-minutes: 30`. Backup: `timeout-minutes: 10`.
+
+### Consolidate `backup.yml` → `repo-backup.yml`
+**Files:** [`backup.yml`](.github/workflows/backup.yml), [`repo-backup.yml`](.github/workflows/repo-backup.yml)
+- Two near-identical backup jobs. `backup.yml` hardcodes `aws-region: us-east-1` and uses `environment: production` (backup doesn't need prod approvals).
+- Make `backup.yml` call `repo-backup.yml` via `uses: ./.github/workflows/repo-backup.yml` with `environment: backup`.
+
+### Remove dead CloudWatch `sequence_token` plumbing
+**File:** [`actions/ship-logs/action.yml:111-133`](.github/actions/ship-logs/action.yml)
+- `put-log-events --sequence-token` has been optional/ignored by CloudWatch since Aug 2023.
+- Delete the token state-tracking code — simplifies the Python block substantially.
+
+### Remove redundant `pip install` in `cdk-review.yml`
+**File:** [`cdk-review.yml:69-72`](.github/workflows/cdk-review.yml)
+- `setup-cdk` composite already installs `requirements.txt` (default `requirements-path`).
+- Delete the separate `Install dependencies` step. Saves ~15–30s per run.
+
+### Pin internal-action ref in `validate-bucket-names.yml`
+**File:** [`validate-bucket-names.yml:36-38`](.github/workflows/validate-bucket-names.yml)
+- Second `actions/checkout` pulls `Specter099/.github` at implicit `main`. Script changes silently alter caller behavior.
+- After SHA-pinning work above, set `ref: <tag-or-sha>` here too.
+
+### Drop `smoke-test-url` input from `cdk-review.yml`
+**File:** [`cdk-review.yml:15-18`](.github/workflows/cdk-review.yml)
+- Declared but never referenced. Vestigial from interface parity with deploy.
+- Either remove or add a `# unused — kept for caller interface parity` comment.
+
+---
+
+## P2 — Code Smell / Consistency
+
+### Reorder `cdk-review.yml` for faster failure
+**File:** [`cdk-review.yml`](.github/workflows/cdk-review.yml)
+- SAST (bandit) currently runs *after* `cdk synth` / Access Analyzer, both of which need AWS creds.
+- Reorder: checkout → setup → lint → bandit → tests → pip-audit → *(AWS creds)* → synth → access-analyzer → nag → diff.
+
+### Extract `ENABLE_LOGS` boilerplate to composite action
+**Files:** every review/deploy workflow
+- Each step repeats the same `if [ "$ENABLE_LOGS" = "true" ]; then … | tee … else … fi` block. ~30 lines of boilerplate per file.
+- Create `actions/run-with-optional-log/action.yml` that takes `command:` and `log-file:` and handles the tee wrapping.
+
+### Fix `find -maxdepth 1` in access-analyzer composite
+**File:** [`actions/access-analyzer/action.yml:36`](.github/actions/access-analyzer/action.yml)
+- `find "$YAML_DIR" -maxdepth 1 …` misses nested CloudFormation YAML directories.
+- Remove `-maxdepth 1` or parameterize.
+
+### Fix npm cache key in `setup-cdk`
+**File:** [`actions/setup-cdk/action.yml:26-30`](.github/actions/setup-cdk/action.yml)
+- `actions/cache` key includes `runner.os` and `cdk-version` but no `hashFiles('**/package-lock.json')` — cache never invalidates when the caller's JS deps change.
+- Either drop the npm cache step entirely (only CDK CLI is installed globally, which is version-keyed) or add a proper hashed key + `restore-keys`.
+
+### Standardize AWS role ARN source
+**File:** [`cdk-deploy.yml:78`](.github/workflows/cdk-deploy.yml)
+- `role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}` — mixed convention. Other workflows require `secrets.AWS_ROLE_ARN` only.
+- Pick one: prefer `vars.AWS_ROLE_ARN` uniformly (ARN isn't secret) and document in `CLAUDE.md`.
+
+### Reconcile `CLAUDE.md` with actual workflow
+**Files:** [`CLAUDE.md`](CLAUDE.md), [`cdk-review.yml`](.github/workflows/cdk-review.yml)
+- `CLAUDE.md` claims `cdk-review` runs **checkov**. No checkov step exists.
+- Either add `checkov -d .` or remove the claim.
+
+### Normalize YAML file headers
+**Files:** all workflows
+- `cdk-review.yml` and `python-ci.yml` start with `---` + `"on":`. Others don't.
+- `.yamllint.yml` already tolerates both. Pick one and apply across the board for consistency.
+
+### Close `gitleaks-action` license gap (contingent)
+**File:** [`gitleaks.yml`](.github/workflows/gitleaks.yml), [`python-ci.yml`](.github/workflows/python-ci.yml)
+- `gitleaks/gitleaks-action@v2` requires a paid license for private-org scans above a free-tier threshold.
+- If that threshold is ever hit, swap to `docker://zricethezav/gitleaks:latest detect --source=. --redact`.
+
+---
+
+## P3 — CI Coverage Parity
+
+### Add missing checks to `static-site-review.yml`
+**File:** [`static-site-review.yml`](.github/workflows/static-site-review.yml)
+- Per the "all checks in CI" mental model, `static-site-review` should match `cdk-review`'s check depth for the infra portion.
+- Missing vs `cdk-review`: SAST (bandit), CDK Nag, IAM Access Analyzer, pip-audit gating, bucket-name validation.
+- Add these as optional/feature-flagged inputs (`enable-access-analyzer`, `enable-bandit`, etc.) so lightweight static sites aren't forced through the full gauntlet.
+
+### Decide: CI-built frontend artifact vs. CD rebuilds?
+**Files:** [`static-site-review.yml`](.github/workflows/static-site-review.yml), [`static-site-deploy.yml`](.github/workflows/static-site-deploy.yml)
+- CI currently `npm run build`s for validation; CD `npm run build`s again before deploy — redundant work and a potential drift source (different node versions, cache state, etc.).
+- Option A: CI uploads `dist/` artifact, CD downloads it. Reproducible, faster CD, but adds artifact plumbing.
+- Option B: Keep current. CI build is validation-only; CD rebuild is the canonical deploy artifact.
+- Decide and document.

--- a/docs/plans/2026-02-19-static-site-cicd.md
+++ b/docs/plans/2026-02-19-static-site-cicd.md
@@ -1,0 +1,414 @@
+# Static Site CI/CD — Reusable Workflows Plan
+
+**Goal:** Add two new reusable workflows (`static-site-review` and `static-site-deploy`) to this
+repo that handle the React/Vite + CDK Python pattern, then wire `scissors-website` to use them.
+
+**Architecture:** The scissors-website repo has a split layout — frontend in
+`scissors-hair-barber/` and CDK infra in `infra/`. The reusable workflows accept `frontend-dir`
+and `infra-dir` inputs so they work for any repo using this pattern. The existing `setup-cdk`
+composite action needs a `requirements-path` input so it can install pip deps from a
+subdirectory.
+
+**Tech Stack:** Node 20, React/Vite, Vitest, ESLint, Python 3.12, AWS CDK 2.1106.1 CLI,
+pytest, pip-audit, GitHub Actions reusable workflows.
+
+---
+
+## Repos involved
+
+| Repo | Changes |
+|------|---------|
+| `Specter099/.github` (this repo) | Extend `setup-cdk`; add `static-site-review.yml` and `static-site-deploy.yml` |
+| `Specter099/scissors-website` | Replace misplaced workflow with thin callers; update dev requirements; configure secrets |
+
+---
+
+## Task 1 — Extend `setup-cdk` with `requirements-path` input
+
+**File:** `.github/actions/setup-cdk/action.yml`
+
+The action currently hardcodes `pip install -r requirements.txt`. scissors-website keeps its
+Python deps at `infra/requirements.txt`. Add a `requirements-path` input (default:
+`requirements.txt`) so the same action works for both layouts without breaking existing callers.
+
+Add to `inputs:`:
+```yaml
+  requirements-path:
+    description: Path to requirements.txt relative to repo root
+    required: false
+    default: "requirements.txt"
+```
+
+Change the install step:
+```yaml
+    - name: Install Python dependencies
+      shell: bash
+      run: pip install -r ${{ inputs.requirements-path }}
+```
+
+Commit: `feat: add requirements-path input to setup-cdk action`
+
+---
+
+## Task 2 — Create `static-site-review.yml`
+
+**File:** `.github/workflows/static-site-review.yml`
+
+Runs on PRs. Lints and tests the frontend, runs CDK infra unit tests, audits Python deps,
+then runs CDK synth/diff and posts the diff as a PR comment.
+
+```yaml
+name: Static Site Review
+
+on:
+  workflow_call:
+    inputs:
+      frontend-dir:
+        description: Path to the frontend project directory (contains package.json)
+        type: string
+        required: true
+      infra-dir:
+        description: Path to the CDK infra directory (contains app.py)
+        type: string
+        required: true
+      aws-region:
+        description: AWS region
+        type: string
+        default: "us-east-1"
+      cdk-version:
+        description: CDK CLI npm version
+        type: string
+        default: "2.1106.1"
+      smoke-test-url:
+        description: Unused in review — accepted for interface consistency with deploy workflow
+        type: string
+        default: ""
+
+jobs:
+  review:
+    name: Lint, Test & Diff
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup CDK
+        uses: Specter099/.github/.github/actions/setup-cdk@main
+        with:
+          cdk-version: ${{ inputs.cdk-version }}
+          requirements-path: ${{ inputs.infra-dir }}/requirements.txt
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix ${{ inputs.frontend-dir }}
+
+      - name: Lint frontend (ESLint)
+        run: npm run lint --prefix ${{ inputs.frontend-dir }}
+
+      - name: Test frontend (Vitest)
+        run: npm run test --prefix ${{ inputs.frontend-dir }}
+
+      - name: Install infra dev dependencies
+        run: pip install -r ${{ inputs.infra-dir }}/requirements-dev.txt
+
+      - name: Test infra (pytest)
+        run: pytest ${{ inputs.infra-dir }}/tests/ -v
+
+      - name: Dependency audit
+        run: pip-audit -r ${{ inputs.infra-dir }}/requirements.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: CDK Synth
+        working-directory: ${{ inputs.infra-dir }}
+        run: cdk synth
+
+      - name: CDK Diff
+        id: diff
+        working-directory: ${{ inputs.infra-dir }}
+        run: |
+          diff_output=$(cdk diff 2>&1) || true
+          echo "$diff_output"
+          {
+            echo "diff<<EOF"
+            echo "$diff_output"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment diff on PR
+        uses: actions/github-script@v7
+        env:
+          DIFF: ${{ steps.diff.outputs.diff }}
+        with:
+          script: |
+            const diff = process.env.DIFF;
+            const body = `### CDK Diff\n\n\`\`\`\n${diff}\n\`\`\``;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.startsWith('### CDK Diff')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+```
+
+Commit: `feat: add static-site-review reusable workflow`
+
+---
+
+## Task 3 — Create `static-site-deploy.yml`
+
+**File:** `.github/workflows/static-site-deploy.yml`
+
+Runs on push to main. Builds the frontend, deploys via CDK, uploads stack outputs as an
+artifact, writes them to the job summary, and optionally runs a smoke test.
+
+```yaml
+name: Static Site Deploy
+
+on:
+  workflow_call:
+    inputs:
+      frontend-dir:
+        description: Path to the frontend project directory (contains package.json)
+        type: string
+        required: true
+      infra-dir:
+        description: Path to the CDK infra directory (contains app.py)
+        type: string
+        required: true
+      aws-region:
+        description: AWS region
+        type: string
+        default: "us-east-1"
+      cdk-version:
+        description: CDK CLI npm version
+        type: string
+        default: "2.1106.1"
+      smoke-test-url:
+        description: URL to curl after deploy for smoke test (optional)
+        type: string
+        default: ""
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup CDK
+        uses: Specter099/.github/.github/actions/setup-cdk@main
+        with:
+          cdk-version: ${{ inputs.cdk-version }}
+          requirements-path: ${{ inputs.infra-dir }}/requirements.txt
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix ${{ inputs.frontend-dir }}
+
+      - name: Build frontend
+        run: npm run build --prefix ${{ inputs.frontend-dir }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: CDK Deploy
+        working-directory: ${{ inputs.infra-dir }}
+        run: cdk deploy --require-approval never --outputs-file outputs.json
+
+      - name: Upload stack outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stack-outputs
+          path: ${{ inputs.infra-dir }}/outputs.json
+          if-no-files-found: ignore
+
+      - name: Write outputs to job summary
+        if: always()
+        run: |
+          if [ -f "${{ inputs.infra-dir }}/outputs.json" ]; then
+            echo "## Stack Outputs" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat "${{ inputs.infra-dir }}/outputs.json" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No stack outputs file found." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Smoke test
+        if: ${{ inputs.smoke-test-url != '' }}
+        run: |
+          status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
+            "${{ inputs.smoke-test-url }}" || echo "000")
+          echo "Smoke test HTTP status: $status"
+          echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
+          echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$status" == "000" ]]; then
+            echo "::warning::Smoke test: curl failed or timed out"
+          else
+            echo "Smoke test passed — endpoint is reachable."
+          fi
+```
+
+Commit: `feat: add static-site-deploy reusable workflow`
+
+---
+
+## Task 4 — Create caller workflows in scissors-website
+
+**Files:**
+- Create: `.github/workflows/review.yml`
+- Create: `.github/workflows/deploy.yml`
+- Delete: `.github/deploy.yml` (wrong location — never triggered by GitHub Actions)
+
+> The existing `.github/deploy.yml` is at the wrong path. GitHub Actions only reads from
+> `.github/workflows/`. That file is not running. The `workflows/` subdirectory does not
+> currently exist in the repo.
+
+`.github/workflows/review.yml`:
+```yaml
+name: Review
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  review:
+    uses: Specter099/.github/.github/workflows/static-site-review.yml@main
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    with:
+      frontend-dir: scissors-hair-barber
+      infra-dir: infra
+      smoke-test-url: "https://scissorshairandbarber.com"
+```
+
+`.github/workflows/deploy.yml`:
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    uses: Specter099/.github/.github/workflows/static-site-deploy.yml@main
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      frontend-dir: scissors-hair-barber
+      infra-dir: infra
+      smoke-test-url: "https://scissorshairandbarber.com"
+```
+
+Commit: `ci: replace misplaced workflow with reusable review + deploy workflows`
+
+---
+
+## Task 5 — Update `infra/requirements-dev.txt` in scissors-website
+
+**File:** `infra/requirements-dev.txt`
+
+Current contents: `pytest==6.2.5` (only). The review workflow runs `pip-audit`, which must
+be installed. Update to:
+
+```
+-r requirements.txt
+pytest>=8.0.0
+pip-audit>=2.8.0
+```
+
+Commit: `chore: add pip-audit to infra dev requirements, update pytest pin`
+
+---
+
+## Task 6 — Configure GitHub for scissors-website (one-time setup)
+
+These are manual steps, not file changes.
+
+**Set `AWS_ROLE_ARN` secret:**
+
+The existing workflow constructs the ARN inline from `secrets.AWS_ACCOUNT_ID`. The reusable
+workflows expect `secrets.AWS_ROLE_ARN` (full ARN). Set it:
+
+```bash
+gh secret set AWS_ROLE_ARN \
+  --repo Specter099/scissors-website \
+  --body "arn:aws:iam::<account-id>:role/GitHubActionsRole-Scissors"
+```
+
+Find the account ID: `aws sts get-caller-identity --query Account --output text`
+
+**Check the IAM role trust policy:**
+
+The `sub` condition must use a wildcard to allow PR branch workflows (not just main):
+
+```json
+"StringLike": {
+  "token.actions.githubusercontent.com:sub": "repo:Specter099/scissors-website:*"
+}
+```
+
+Check: `aws iam get-role --role-name GitHubActionsRole-Scissors --query Role.AssumeRolePolicyDocument`
+
+If pinned to `ref:refs/heads/main`, update it to `*`.
+
+**Create `production` environment:**
+
+Go to **github.com/Specter099/scissors-website → Settings → Environments → New environment**
+and create `production`. Required by the deploy workflow; without it the job queues indefinitely.
+
+---
+
+## Checklist
+
+- [ ] Task 1: Extend `setup-cdk` with `requirements-path` input
+- [ ] Task 2: Create `static-site-review.yml` in this repo
+- [ ] Task 3: Create `static-site-deploy.yml` in this repo
+- [ ] Task 4: Create caller workflows in `scissors-website`
+- [ ] Task 5: Update `infra/requirements-dev.txt` in `scissors-website`
+- [ ] Task 6: Set `AWS_ROLE_ARN` secret, fix trust policy, create `production` environment
+- [ ] Open a PR on `scissors-website` → confirm `Review / Lint, Test & Diff` passes
+- [ ] Merge → confirm `Deploy / Build & Deploy` passes

--- a/docs/plans/2026-03-03-python-ci-design.md
+++ b/docs/plans/2026-03-03-python-ci-design.md
@@ -1,0 +1,54 @@
+# Design: General Python CI Workflow
+
+**Date:** 2026-03-03
+**Status:** Approved
+
+## Goal
+
+A reusable `workflow_call` workflow for pure Python projects (no CDK, no AWS). Runs ruff linting, ruff format check, gitleaks secrets scan, and pytest.
+
+## File
+
+`.github/workflows/python-ci.yml`
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `python-version` | no | `"3.12"` | Python version for `actions/setup-python` |
+| `requirements-path` | no | `"requirements-dev.txt"` | Path to dev requirements file |
+| `tests-dir` | no | `"tests/"` | Directory passed to pytest |
+
+## Permissions
+
+`contents: read` only. No AWS credentials, no PR write access needed.
+
+## Steps (in order)
+
+1. `actions/checkout@v4` — `fetch-depth: 0` (full history required for gitleaks)
+2. `actions/setup-python@v5` — installs the requested Python version
+3. `pip install -r <requirements-path>` — installs dev dependencies
+4. `ruff check .` — linting
+5. `ruff format --check .` — format enforcement
+6. `gitleaks-action` (`zricethezav/gitleaks-action@v2`) — secrets scan over full git history; uses `GITHUB_TOKEN` implicitly
+7. `pytest <tests-dir> -v` — unit tests
+
+## Design Decisions
+
+- **Single job, sequential steps** — mirrors existing repo style; tools are fast enough that parallelism adds no meaningful benefit
+- **gitleaks** — chosen for git-history awareness and official GitHub Action support; no baseline file management needed
+- **ruff format --check** — enforces formatting as a hard gate, not just linting
+- **`fetch-depth: 0`** — required for gitleaks to scan full commit history, not just the latest commit
+- **No secrets required** — `GITHUB_TOKEN` is injected automatically by GitHub Actions
+
+## Usage Example
+
+```yaml
+jobs:
+  ci:
+    uses: Specter099/.github/.github/workflows/python-ci.yml@main
+    with:
+      python-version: "3.12"         # optional
+      requirements-path: requirements-dev.txt  # optional
+      tests-dir: tests/              # optional
+```

--- a/docs/plans/2026-03-03-python-ci.md
+++ b/docs/plans/2026-03-03-python-ci.md
@@ -1,0 +1,179 @@
+# Python CI Workflow Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a reusable `python-ci` workflow that runs ruff lint, ruff format check, gitleaks secrets scan, and pytest for pure Python projects.
+
+**Architecture:** Single `workflow_call` reusable workflow in `.github/workflows/python-ci.yml`. Sequential steps in one job — no AWS, no CDK, no PR write access needed. Full git history checkout (`fetch-depth: 0`) required for gitleaks.
+
+**Tech Stack:** GitHub Actions, `actions/setup-python@v5`, `zricethezav/gitleaks-action@v2`, ruff, pytest.
+
+---
+
+### Task 1: Create feature branch
+
+**Files:**
+- No files yet
+
+**Step 1: Verify current branch and create feature branch**
+
+Run:
+```bash
+git status
+git checkout -b feature/python-ci-workflow
+```
+
+Expected: switched to new branch `feature/python-ci-workflow`
+
+---
+
+### Task 2: Write the `python-ci.yml` workflow
+
+**Files:**
+- Create: `.github/workflows/python-ci.yml`
+
+**Step 1: Create the workflow file**
+
+Create `.github/workflows/python-ci.yml` with this exact content:
+
+```yaml
+name: Python CI
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to use
+        type: string
+        default: "3.12"
+      requirements-path:
+        description: Path to dev requirements file
+        type: string
+        default: "requirements-dev.txt"
+      tests-dir:
+        description: Directory to run pytest against
+        type: string
+        default: "tests/"
+
+jobs:
+  ci:
+    name: Lint, Secrets & Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install dev dependencies
+        run: pip install -r ${{ inputs.requirements-path }}
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Format check (ruff)
+        run: ruff format --check .
+
+      - name: Secrets scan (gitleaks)
+        uses: zricethezav/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unit tests (pytest)
+        run: pytest ${{ inputs.tests-dir }} -v
+```
+
+**Step 2: Verify YAML is valid**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/python-ci.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/python-ci.yml
+git commit -m "feat: add reusable python-ci workflow"
+```
+
+---
+
+### Task 3: Update README.md
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add the `python-ci` entry to the Quick Reference table**
+
+Find the Quick Reference table and add a row:
+
+```markdown
+| `python-ci` | Workflow | PR check for any pure Python project |
+```
+
+**Step 2: Add the full documentation section**
+
+Add a new `## Python CI` section after the existing `## Utilities` section:
+
+```markdown
+## Python CI
+
+### `python-ci`
+
+Lints, format-checks, and secret-scans a pure Python project, then runs pytest. No AWS credentials required.
+
+**Inputs**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `python-version` | no | `"3.12"` | Python version |
+| `requirements-path` | no | `"requirements-dev.txt"` | Path to dev requirements file |
+| `tests-dir` | no | `"tests/"` | Directory passed to pytest |
+
+**Usage**
+
+```yaml
+jobs:
+  ci:
+    uses: Specter099/.github/.github/workflows/python-ci.yml@main
+    with:
+      python-version: "3.12"          # optional
+      requirements-path: requirements-dev.txt  # optional
+      tests-dir: tests/               # optional
+```
+
+> **Note:** gitleaks scans the full git history (`fetch-depth: 0`). No secrets are required — `GITHUB_TOKEN` is injected automatically by GitHub Actions.
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document python-ci workflow in README"
+```
+
+---
+
+### Task 4: Open PR
+
+**Step 1: Push branch and open PR**
+
+```bash
+git push -u origin feature/python-ci-workflow
+gh pr create \
+  --title "feat: add reusable python-ci workflow" \
+  --body "Adds a general-purpose Python CI reusable workflow with ruff lint, ruff format check, gitleaks secrets scan, and pytest. No AWS credentials required." \
+  --base main
+```
+
+Expected: PR URL printed to stdout.

--- a/scripts/check_no_public_access.py
+++ b/scripts/check_no_public_access.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Check CloudFormation templates for public access using AWS IAM Access Analyzer.
+
+Scans *.template.json files in the given directory, extracts resource policies
+from supported resource types, and calls CheckNoPublicAccess for each.
+
+Exit codes:
+  0 — all resources pass (or no applicable resources found)
+  1 — one or more resources grant public access (when --fail-on-public-access)
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+# Maps CloudFormation resource type → (policy property, Access Analyzer resource type)
+POLICY_MAP = {
+    "AWS::S3::BucketPolicy": ("PolicyDocument", "AWS::S3::Bucket"),
+    "AWS::SQS::QueuePolicy": ("PolicyDocument", "AWS::SQS::Queue"),
+    "AWS::SNS::TopicPolicy": ("PolicyDocument", "AWS::SNS::Topic"),
+    "AWS::KMS::Key": ("KeyPolicy", "AWS::KMS::Key"),
+    "AWS::ECR::Repository": ("RepositoryPolicyText", "AWS::ECR::Repository"),
+    "AWS::SecretsManager::ResourcePolicy": (
+        "ResourcePolicy",
+        "AWS::SecretsManager::Secret",
+    ),
+    "AWS::IAM::Role": (
+        "AssumeRolePolicyDocument",
+        "AWS::IAM::AssumeRolePolicyDocument",
+    ),
+}
+
+# CDK metadata files to skip
+SKIP_FILES = {"manifest.json", "tree.json", "cdk.out"}
+
+
+def find_templates(template_dir: Path) -> list[Path]:
+    templates = []
+    for path in sorted(template_dir.rglob("*.template.json")):
+        if path.name not in SKIP_FILES and not path.name.startswith("asset."):
+            templates.append(path)
+    return templates
+
+
+def extract_policies(template: dict) -> list[tuple[str, str, dict]]:
+    """Return list of (logical_id, analyzer_resource_type, policy_document)."""
+    results = []
+    resources = template.get("Resources", {})
+    for logical_id, resource in resources.items():
+        cf_type = resource.get("Type", "")
+        if cf_type not in POLICY_MAP:
+            continue
+        policy_prop, analyzer_type = POLICY_MAP[cf_type]
+        policy_doc = resource.get("Properties", {}).get(policy_prop)
+        if policy_doc is None:
+            continue
+        results.append((logical_id, analyzer_type, policy_doc))
+    return results
+
+
+def check_policy(client, logical_id: str, analyzer_type: str, policy_doc: dict) -> dict:
+    """Call CheckNoPublicAccess and return a result dict."""
+    try:
+        resp = client.check_no_public_access(
+            policyDocument=json.dumps(policy_doc),
+            resourceType=analyzer_type,
+        )
+        is_public = resp.get("result") == "FAIL"
+        reasons = [r.get("description", "") for r in resp.get("reasons", [])]
+        return {
+            "logical_id": logical_id,
+            "resource_type": analyzer_type,
+            "public": is_public,
+            "reasons": reasons,
+        }
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        msg = exc.response["Error"]["Message"]
+        return {
+            "logical_id": logical_id,
+            "resource_type": analyzer_type,
+            "public": False,
+            "error": f"{code}: {msg}",
+        }
+
+
+def write_summary(findings: list[dict], template_name: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a") as f:
+        f.write(f"\n### Access Analyzer — `{template_name}`\n\n")
+        if not findings:
+            f.write("_No applicable resources found._\n")
+            return
+        f.write("| Resource | Type | Result |\n")
+        f.write("|---|---|---|\n")
+        for r in findings:
+            if "error" in r:
+                icon = "⚠️"
+                status = f"Error: {r['error']}"
+            elif r["public"]:
+                icon = "❌"
+                reasons = (
+                    "; ".join(r["reasons"])
+                    if r["reasons"]
+                    else "public access detected"
+                )
+                status = f"FAIL — {reasons}"
+            else:
+                icon = "✅"
+                status = "PASS"
+            f.write(
+                f"| `{r['logical_id']}` | `{r['resource_type']}` | {icon} {status} |\n"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--template-dir",
+        default="cdk.out",
+        help="Directory containing CloudFormation *.template.json files (default: cdk.out)",
+    )
+    parser.add_argument(
+        "--aws-region",
+        default=os.environ.get("AWS_REGION", "us-east-1"),
+        help="AWS region for Access Analyzer API calls",
+    )
+    parser.add_argument(
+        "--fail-on-public-access",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Exit 1 if public access is detected (default: true)",
+    )
+    args = parser.parse_args()
+
+    template_dir = Path(args.template_dir)
+    if not template_dir.is_dir():
+        print(
+            f"::error::template-dir '{template_dir}' does not exist or is not a directory"
+        )
+        return 1
+
+    templates = find_templates(template_dir)
+    if not templates:
+        print(
+            f"::notice::No *.template.json files found in '{template_dir}' — skipping check"
+        )
+        return 0
+
+    client = boto3.client("accessanalyzer", region_name=args.aws_region)
+
+    total_violations = 0
+
+    for template_path in templates:
+        template_name = template_path.name
+        print(f"\n=== {template_name} ===")
+
+        try:
+            template = json.loads(template_path.read_text())
+        except json.JSONDecodeError as exc:
+            print(f"::warning::Could not parse {template_name}: {exc}")
+            continue
+
+        policies = extract_policies(template)
+        if not policies:
+            print("  No applicable resources found — skipping")
+            write_summary([], template_name)
+            continue
+
+        findings = []
+        for logical_id, analyzer_type, policy_doc in policies:
+            result = check_policy(client, logical_id, analyzer_type, policy_doc)
+            findings.append(result)
+
+            if "error" in result:
+                print(f"  ⚠  {logical_id} ({analyzer_type}) — error: {result['error']}")
+            elif result["public"]:
+                total_violations += 1
+                reasons = (
+                    "; ".join(result["reasons"])
+                    if result["reasons"]
+                    else "public access detected"
+                )
+                print(f"  ✗  {logical_id} ({analyzer_type}) — FAIL: {reasons}")
+            else:
+                print(f"  ✓  {logical_id} ({analyzer_type}) — PASS")
+
+        write_summary(findings, template_name)
+
+    print()
+    if total_violations > 0:
+        print(f"::error::{total_violations} resource(s) grant public access")
+        return 1 if args.fail_on_public_access else 0
+
+    print("All resources passed the no-public-access check.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_bucket_names.py
+++ b/scripts/validate_bucket_names.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+validate_bucket_names.py
+
+Scans CDK Python source files for S3 bucket_name= arguments and validates
+they conform to the required naming convention:
+
+    {prefix}-{12-digit-account-id}-{aws-region}-an
+
+Examples of VALID names:
+    bitwarden-logs-123456789012-us-east-1-an
+    cloudfront-access-123456789012-eu-west-2-an
+
+Examples of INVALID names:
+    my-bucket                          (missing account/region/suffix)
+    bitwarden-123456789012-us-east-1   (missing -an suffix)
+    bitwarden-12345-us-east-1-an       (account ID not 12 digits)
+    bitwarden_logs-123456789012-us-east-1-an  (underscore in prefix)
+
+Usage:
+    python scripts/validate_bucket_names.py [--path <dir>]
+
+Exit codes:
+    0 — all bucket names conform (or none found)
+    1 — one or more violations found
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Naming convention regex
+# ---------------------------------------------------------------------------
+# Segments:
+#   prefix      : one or more lowercase alphanumeric/hyphen tokens (kebab-case)
+#   account-id  : exactly 12 digits
+#   region      : standard AWS region format  e.g. us-east-1, ap-southeast-2
+#   suffix      : literal "an"
+# ---------------------------------------------------------------------------
+BUCKET_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]+-\d{12}-[a-z]{2}-[a-z]+-\d-an$")
+
+
+def is_valid_bucket_name(name: str) -> bool:
+    return bool(BUCKET_NAME_RE.match(name))
+
+
+def extract_bucket_names_from_file(path: Path) -> list[tuple[int, str]]:
+    """
+    Parse a Python file with the AST and extract string literals passed as
+    the `bucket_name` keyword argument to any function/constructor call.
+
+    Returns a list of (line_number, bucket_name_value) tuples.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        print(f"  Warning: Could not parse {path}: {exc}", file=sys.stderr)
+        return []
+
+    results = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "bucket_name" and isinstance(kw.value, ast.Constant):
+                results.append((kw.value.lineno, str(kw.value.value)))
+
+    return results
+
+
+def scan_directory(root: Path) -> tuple[list[tuple[Path, int, str]], int]:
+    """
+    Recursively scan all .py files under root for bucket_name= arguments.
+
+    Returns a tuple of (violations, checked_count).
+    """
+    violations = []
+    checked = 0
+
+    for py_file in sorted(root.rglob("*.py")):
+        parts = py_file.parts
+        if any(
+            p in parts
+            for p in ("cdk.out", ".venv", "venv", "node_modules", "__pycache__")
+        ):
+            continue
+
+        names = extract_bucket_names_from_file(py_file)
+        for lineno, name in names:
+            checked += 1
+            if not is_valid_bucket_name(name):
+                violations.append((py_file, lineno, name))
+
+    return violations, checked
+
+
+def scan_templates(template_dir: Path) -> tuple[list[tuple[Path, str, str]], int]:
+    """
+    Scan CloudFormation *.template.json files for AWS::S3::Bucket resources
+    with a literal-string BucketName property and validate each name.
+
+    Returns (violations, checked_count).
+    Each violation is (template_path, logical_id, bucket_name).
+    """
+    skip = {"manifest.json", "tree.json"}
+    violations = []
+    checked = 0
+
+    for tpl_path in sorted(template_dir.rglob("*.template.json")):
+        if tpl_path.name in skip or tpl_path.name.startswith("asset."):
+            continue
+        try:
+            template = json.loads(tpl_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"  Warning: Could not parse {tpl_path.name}: {exc}", file=sys.stderr)
+            continue
+
+        for logical_id, resource in template.get("Resources", {}).items():
+            if resource.get("Type") != "AWS::S3::Bucket":
+                continue
+            bucket_name = resource.get("Properties", {}).get("BucketName")
+            if bucket_name is None or not isinstance(bucket_name, str):
+                # No explicit name (auto-generated) or intrinsic function — skip
+                continue
+            checked += 1
+            if not is_valid_bucket_name(bucket_name):
+                violations.append((tpl_path, logical_id, bucket_name))
+
+    return violations, checked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate S3 bucket names in CDK source or synthesized templates."
+    )
+    parser.add_argument(
+        "--path",
+        default=None,
+        help="Root directory to scan for bucket_name= in Python source files",
+    )
+    parser.add_argument(
+        "--template-dir",
+        default=None,
+        help="Directory containing CloudFormation *.template.json files (e.g. cdk.out)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress passing output; only print violations",
+    )
+    args = parser.parse_args()
+
+    if not args.path and not args.template_dir:
+        parser.error(
+            "Provide --path (Python source scan) or --template-dir (CF template scan), or both."
+        )
+
+    total_violations = 0
+
+    if args.template_dir:
+        tdir = Path(args.template_dir).resolve()
+        if not tdir.is_dir():
+            print(f"Error: --template-dir not found: {tdir}", file=sys.stderr)
+            return 1
+        print(f"Scanning CloudFormation templates in {tdir} ...")
+        tpl_violations, tpl_checked = scan_templates(tdir)
+        if tpl_violations:
+            total_violations += len(tpl_violations)
+            print(f"\n{len(tpl_violations)} bucket name violation(s) in templates:\n")
+            print("   Required pattern: {prefix}-{12-digit-account-id}-{aws-region}-an")
+            print("   Example:          bitwarden-logs-123456789012-us-east-1-an\n")
+            for tpl_path, logical_id, name in tpl_violations:
+                print(f"   {tpl_path.name} / {logical_id}")
+                print(f'     BucketName = "{name}"')
+                print()
+        elif not args.quiet:
+            print(f"   Checked {tpl_checked} explicit bucket name(s) — all conform.")
+
+    if args.path:
+        root = Path(args.path).resolve()
+        if not root.is_dir():
+            print(f"Error: --path not found: {root}", file=sys.stderr)
+            return 1
+        print(f"\nScanning {root} for S3 bucket_name= arguments...")
+        src_violations, src_checked = scan_directory(root)
+        print(
+            f"   Found {src_checked} hardcoded bucket name(s) across all .py files.\n"
+        )
+        if src_violations:
+            total_violations += len(src_violations)
+            print(f"{len(src_violations)} bucket name violation(s) found:\n")
+            print("   Required pattern: {prefix}-{12-digit-account-id}-{aws-region}-an")
+            print("   Example:          bitwarden-logs-123456789012-us-east-1-an\n")
+            for file_path, lineno, name in src_violations:
+                rel = (
+                    file_path.relative_to(root)
+                    if file_path.is_relative_to(root)
+                    else file_path
+                )
+                print(f"   {rel}:{lineno}")
+                print(f'     bucket_name = "{name}"')
+                print()
+        elif not args.quiet:
+            print("All bucket names conform to the naming convention.")
+            print("   Pattern: {prefix}-{12-digit-account-id}-{aws-region}-an")
+
+    if total_violations > 0:
+        return 1
+    if not args.quiet:
+        print("All checked bucket names pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR #64 ([commit 284ee9b7](https://github.com/Specter099/.github/commit/284ee9b773eea252ef249308523049305e51e49c), merged 2026-05-14) was supposed to add `env:` passthrough to **3 files** for command-injection hardening, but the merge-conflict resolution accidentally deleted **19 unrelated files / 2,925 lines** from `main`. This PR restores them from `04e0def6` (the commit immediately before #64) while leaving #64's three intentional security fixes intact.

## Impact

The deletion of `.github/workflows/repo-backup.yml` broke the weekly Sunday repo-backup workflow for **every Specter099 repo** that calls `uses: Specter099/.github/.github/workflows/repo-backup.yml@main`. On 2026-05-17 ~05:36–05:54 UTC, ~25 caller workflows failed with "This run likely failed because of a workflow file issue."

In addition, every other reusable workflow consumed by caller repos was deleted: `cdk-review.yml`, `cdk-deploy.yml`, `python-ci.yml`, `gitleaks.yml`, `access-analyzer-check.yml`, `validate-bucket-names.yml`, and the `.github` repo's own `backup.yml`. The `access-analyzer` and `ship-logs` composite actions were also deleted.

## What this PR does

Restores each accidentally-deleted file from `04e0def6` (parent of `284ee9b7`):

**Reusable workflows (10)**
- `.github/workflows/repo-backup.yml` (95 lines)
- `.github/workflows/backup.yml` (57)
- `.github/workflows/cdk-review.yml` (287)
- `.github/workflows/cdk-deploy.yml` (189)
- `.github/workflows/python-ci.yml` (260)
- `.github/workflows/gitleaks.yml` (21)
- `.github/workflows/access-analyzer-check.yml` (63)
- `.github/workflows/validate-bucket-names.yml` (85)

**Composite actions (2)**
- `.github/actions/access-analyzer/action.yml` (183)
- `.github/actions/ship-logs/action.yml` (184)

**Helper scripts (2)**
- `scripts/check_no_public_access.py` (208)
- `scripts/validate_bucket_names.py` (220)

**Docs / config (5)**
- `CLAUDE.md`, `README.md`, `TODO.md`
- `docs/plans/2026-02-19-static-site-cicd.md`, `docs/plans/2026-03-03-python-ci-design.md`, `docs/plans/2026-03-03-python-ci.md`
- `.yamllint.yml`

## What this PR does NOT do

The three files PR #64 intentionally modified retain #64's security fixes — they are not touched:
- `.github/actions/setup-cdk/action.yml`
- `.github/workflows/static-site-review.yml`
- `.github/workflows/static-site-deploy.yml`

Verified: zero `\${{ inputs.* }}` interpolations remain inside `run:` blocks in those three files.

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] After merge, re-run a failed backup workflow manually on one repo (e.g. `gh workflow run backup.yml --repo Specter099/knit-stitch-website`) and verify success
- [ ] Wait for next Sunday's scheduled fleet-wide backup and confirm all repos succeed