### PR TITLE
fix: harden caller-controlled shell inputs in reusable workflows

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -97,6 +97,13 @@ jobs:
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
+          # Guard caller-controlled input before unquoted expansion: only
+          # '--all' or space-separated stack names are accepted, so flags or
+          # shell metacharacters can't be smuggled into the cdk command.
+          if [[ ! "$CDK_STACKS" =~ ^(--all|[A-Za-z0-9_-]+( [A-Za-z0-9_-]+)*)$ ]]; then
+            echo "::error::invalid stacks input '$CDK_STACKS' — must be '--all' or space-separated stack names"
+            exit 1
+          fi
           if [ "$ENABLE_LOGS" = "true" ]; then
             cdk deploy $CDK_STACKS --require-approval never --verbose --outputs-file outputs.json 2>&1 \
               | awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' \

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -186,10 +186,18 @@ jobs:
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
+          # Run synth on its own so a synth failure fails the step, then grep
+          # the captured output. grep finding no Nag lines is fine (|| true) —
+          # previously the single pipeline swallowed synth errors too.
+          if ! CDK_NAG=true cdk synth > "$RUNNER_TEMP/cdk-nag-synth.log" 2>&1; then
+            cat "$RUNNER_TEMP/cdk-nag-synth.log"
+            echo "::error::cdk synth failed during CDK Nag run"
+            exit 1
+          fi
           if [ "$ENABLE_LOGS" = "true" ]; then
-            CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" | tee "$RUNNER_TEMP/ci-logs/cdk-nag.log" || true
+            grep -E "^\[.*Nag\]|AwsSolutions" "$RUNNER_TEMP/cdk-nag-synth.log" | tee "$RUNNER_TEMP/ci-logs/cdk-nag.log" || true
           else
-            CDK_NAG=true cdk synth 2>&1 | grep -E "^\[.*Nag\]|AwsSolutions" || true
+            grep -E "^\[.*Nag\]|AwsSolutions" "$RUNNER_TEMP/cdk-nag-synth.log" || true
           fi
 
       - name: CDK Diff

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,7 +24,10 @@ name: Python CI
         type: string
         default: "requirements-dev.txt"
       install-command:
-        description: Custom install command (overrides requirements-path)
+        description: >-
+          Custom install command (overrides requirements-path). Must be a
+          single command — shell operators (;, |, &&, redirects, globs) are
+          not interpreted.
         type: string
         default: ""
       tests-dir:
@@ -120,7 +123,12 @@ jobs:
           REQUIREMENTS_PATH: ${{ inputs.requirements-path }}
         run: |
           if [ -n "$INSTALL_COMMAND" ]; then
-            eval "$INSTALL_COMMAND"
+            # No eval: expand unquoted so the shell word-splits but never
+            # re-parses operators — `;`, `|`, `&&`, redirects, and globs in
+            # the input become literal arguments instead of shell syntax.
+            # set -f disables globbing so patterns like .[dev] stay literal.
+            set -f
+            $INSTALL_COMMAND
           else
             pip install -r "$REQUIREMENTS_PATH"
           fi


### PR DESCRIPTION
## Summary

Closes the two remaining **P0** items from [TODO.md](https://github.com/Specter099/.github/blob/main/TODO.md) plus one related hardening:

- **python-ci.yml** — `install-command` was executed via `eval`, so any shell syntax in the caller-supplied input was interpreted. Now expanded unquoted with globbing disabled (`set -f`): the shell word-splits but never re-parses operators, so `;`, `|`, `&&`, redirects, and globs become literal arguments. Input description updated to document single-command semantics. No current caller uses `install-command`.
- **cdk-deploy.yml** — `stacks` input is now validated against `--all` or space-separated `[A-Za-z0-9_-]+` names before unquoted expansion into `cdk deploy`, so flags or metacharacters can't be smuggled in. Existing callers (`--all` default, `Route53Stack`, `KnitNStitchStack`) all pass the guard.
- **cdk-review.yml** — the CDK Nag step ran `cdk synth | grep ... || true`, which swallowed synth failures. Synth now runs on its own (failing the step on error) and grep runs on the captured output, where `|| true` only covers "no Nag findings".

## Testing

- `yamllint -c .yamllint.yml .github/` passes
- Verified caller repos' inputs against the new `stacks` guard (bitwarden-cdk, route53-cdk, static-site-infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)