### PR TITLE
fix: harden helper scripts — f-string validation, stringified policies, exit code 2

### DIFF
--- a/scripts/check_no_public_access.py
+++ b/scripts/check_no_public_access.py
@@ -8,6 +8,8 @@ from supported resource types, and calls CheckNoPublicAccess for each.
 Exit codes:
   0 — all resources pass (or no applicable resources found)
   1 — one or more resources grant public access (when --fail-on-public-access)
+  2 — scan incomplete: a template or policy could not be parsed, or an
+      Access Analyzer API call failed (no violations found otherwise)
 """
 
 import argparse
@@ -47,9 +49,19 @@ def find_templates(template_dir: Path) -> list[Path]:
     return templates
 
 
-def extract_policies(template: dict) -> list[tuple[str, str, dict]]:
-    """Return list of (logical_id, analyzer_resource_type, policy_document)."""
+def extract_policies(
+    template: dict,
+) -> tuple[list[tuple[str, str, dict]], list[tuple[str, str]]]:
+    """
+    Return (policies, errors).
+
+    policies — list of (logical_id, analyzer_resource_type, policy_document).
+    Policy documents serialized as JSON strings (valid CloudFormation) are
+    parsed into dicts. errors — list of (logical_id, message) for policies
+    that could not be parsed.
+    """
     results = []
+    errors = []
     resources = template.get("Resources", {})
     for logical_id, resource in resources.items():
         cf_type = resource.get("Type", "")
@@ -59,8 +71,14 @@ def extract_policies(template: dict) -> list[tuple[str, str, dict]]:
         policy_doc = resource.get("Properties", {}).get(policy_prop)
         if policy_doc is None:
             continue
+        if isinstance(policy_doc, str):
+            try:
+                policy_doc = json.loads(policy_doc)
+            except json.JSONDecodeError as exc:
+                errors.append((logical_id, f"unparseable policy string: {exc}"))
+                continue
         results.append((logical_id, analyzer_type, policy_doc))
-    return results
+    return results, errors
 
 
 def check_policy(client, logical_id: str, analyzer_type: str, policy_doc: dict) -> dict:
@@ -157,6 +175,7 @@ def main() -> int:
     client = boto3.client("accessanalyzer", region_name=args.aws_region)
 
     total_violations = 0
+    total_errors = 0
 
     for template_path in templates:
         template_name = template_path.name
@@ -166,10 +185,14 @@ def main() -> int:
             template = json.loads(template_path.read_text())
         except json.JSONDecodeError as exc:
             print(f"::warning::Could not parse {template_name}: {exc}")
+            total_errors += 1
             continue
 
-        policies = extract_policies(template)
-        if not policies:
+        policies, policy_errors = extract_policies(template)
+        for logical_id, message in policy_errors:
+            print(f"  ⚠  {logical_id} — error: {message}")
+            total_errors += 1
+        if not policies and not policy_errors:
             print("  No applicable resources found — skipping")
             write_summary([], template_name)
             continue
@@ -181,6 +204,7 @@ def main() -> int:
 
             if "error" in result:
                 print(f"  ⚠  {logical_id} ({analyzer_type}) — error: {result['error']}")
+                total_errors += 1
             elif result["public"]:
                 total_violations += 1
                 reasons = (
@@ -198,6 +222,13 @@ def main() -> int:
     if total_violations > 0:
         print(f"::error::{total_violations} resource(s) grant public access")
         return 1 if args.fail_on_public_access else 0
+
+    if total_errors > 0:
+        print(
+            f"::error::{total_errors} template(s)/resource(s) could not be "
+            "checked — scan incomplete"
+        )
+        return 2
 
     print("All resources passed the no-public-access check.")
     return 0

--- a/scripts/validate_bucket_names.py
+++ b/scripts/validate_bucket_names.py
@@ -17,12 +17,17 @@ Examples of INVALID names:
     bitwarden-12345-us-east-1-an       (account ID not 12 digits)
     bitwarden_logs-123456789012-us-east-1-an  (underscore in prefix)
 
+f-strings (e.g. bucket_name=f"logs-{account}-{region}-an") are validated
+best-effort: interpolated expressions can't be resolved statically, so only
+the literal parts are checked (kebab-case characters, literal "-an" suffix).
+
 Usage:
     python scripts/validate_bucket_names.py [--path <dir>]
 
 Exit codes:
     0 — all bucket names conform (or none found)
     1 — one or more violations found
+    2 — scan incomplete: a Python file or template could not be parsed
 """
 
 import argparse
@@ -40,6 +45,8 @@ from pathlib import Path
 #   account-id  : exactly 12 digits
 #   region      : standard AWS region format  e.g. us-east-1, ap-southeast-2
 #   suffix      : literal "an"
+# The region segment is intentionally loose ({2 letters}-{word}-{digit})
+# to avoid maintaining a hard-coded list of AWS regions.
 # ---------------------------------------------------------------------------
 BUCKET_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]+-\d{12}-[a-z]{2}-[a-z]+-\d-an$")
 
@@ -48,39 +55,77 @@ def is_valid_bucket_name(name: str) -> bool:
     return bool(BUCKET_NAME_RE.match(name))
 
 
-def extract_bucket_names_from_file(path: Path) -> list[tuple[int, str]]:
-    """
-    Parse a Python file with the AST and extract string literals passed as
-    the `bucket_name` keyword argument to any function/constructor call.
+def _render_fstring(node: ast.JoinedStr) -> str:
+    """Render an f-string for display: literal parts verbatim, interpolated
+    expressions as {expr} placeholders."""
+    parts = []
+    for value in node.values:
+        if isinstance(value, ast.Constant):
+            parts.append(str(value.value))
+        elif isinstance(value, ast.FormattedValue):
+            parts.append("{" + ast.unparse(value.value) + "}")
+    return "".join(parts)
 
-    Returns a list of (line_number, bucket_name_value) tuples.
+
+def _fstring_conforms(node: ast.JoinedStr) -> bool:
     """
-    try:
-        source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError as exc:
-        print(f"  Warning: Could not parse {path}: {exc}", file=sys.stderr)
-        return []
+    Best-effort validation of an f-string bucket name. Interpolated values
+    can't be resolved statically, so check what is checkable:
+      - every literal part uses only kebab-case characters [a-z0-9-]
+      - the name ends with a literal "-an" suffix
+    """
+    last = node.values[-1] if node.values else None
+    if not (isinstance(last, ast.Constant) and str(last.value).endswith("-an")):
+        return False
+    return all(
+        re.fullmatch(r"[a-z0-9-]*", str(value.value))
+        for value in node.values
+        if isinstance(value, ast.Constant)
+    )
+
+
+def extract_bucket_names_from_file(path: Path) -> list[tuple[int, str, bool]]:
+    """
+    Parse a Python file with the AST and extract values passed as the
+    `bucket_name` keyword argument to any function/constructor call.
+
+    Handles string literals (validated against the full convention) and
+    f-strings (validated best-effort on their literal parts).
+
+    Returns a list of (line_number, display_value, is_valid) tuples.
+    Raises SyntaxError if the file cannot be parsed.
+    """
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
 
     results = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         for kw in node.keywords:
-            if kw.arg == "bucket_name" and isinstance(kw.value, ast.Constant):
-                results.append((kw.value.lineno, str(kw.value.value)))
+            if kw.arg != "bucket_name":
+                continue
+            if isinstance(kw.value, ast.Constant):
+                name = str(kw.value.value)
+                results.append((kw.value.lineno, name, is_valid_bucket_name(name)))
+            elif isinstance(kw.value, ast.JoinedStr):
+                display = _render_fstring(kw.value)
+                results.append((kw.value.lineno, display, _fstring_conforms(kw.value)))
 
     return results
 
 
-def scan_directory(root: Path) -> tuple[list[tuple[Path, int, str]], int]:
+def scan_directory(root: Path) -> tuple[list[tuple[Path, int, str]], int, int]:
     """
     Recursively scan all .py files under root for bucket_name= arguments.
 
-    Returns a tuple of (violations, checked_count).
+    Returns a tuple of (violations, checked_count, parse_errors).
+    Files that fail to parse are counted in parse_errors rather than
+    silently skipped, so callers can fail loudly on an incomplete scan.
     """
     violations = []
     checked = 0
+    parse_errors = 0
 
     for py_file in sorted(root.rglob("*.py")):
         parts = py_file.parts
@@ -90,26 +135,34 @@ def scan_directory(root: Path) -> tuple[list[tuple[Path, int, str]], int]:
         ):
             continue
 
-        names = extract_bucket_names_from_file(py_file)
-        for lineno, name in names:
+        try:
+            names = extract_bucket_names_from_file(py_file)
+        except SyntaxError as exc:
+            print(f"  Warning: Could not parse {py_file}: {exc}", file=sys.stderr)
+            parse_errors += 1
+            continue
+        for lineno, name, valid in names:
             checked += 1
-            if not is_valid_bucket_name(name):
+            if not valid:
                 violations.append((py_file, lineno, name))
 
-    return violations, checked
+    return violations, checked, parse_errors
 
 
-def scan_templates(template_dir: Path) -> tuple[list[tuple[Path, str, str]], int]:
+def scan_templates(template_dir: Path) -> tuple[list[tuple[Path, str, str]], int, int]:
     """
     Scan CloudFormation *.template.json files for AWS::S3::Bucket resources
     with a literal-string BucketName property and validate each name.
 
-    Returns (violations, checked_count).
-    Each violation is (template_path, logical_id, bucket_name).
+    Returns (violations, checked_count, parse_errors).
+    Each violation is (template_path, logical_id, bucket_name). Templates
+    that fail to parse are counted in parse_errors rather than silently
+    skipped, so callers can fail loudly on an incomplete scan.
     """
     skip = {"manifest.json", "tree.json"}
     violations = []
     checked = 0
+    parse_errors = 0
 
     for tpl_path in sorted(template_dir.rglob("*.template.json")):
         if tpl_path.name in skip or tpl_path.name.startswith("asset."):
@@ -118,6 +171,7 @@ def scan_templates(template_dir: Path) -> tuple[list[tuple[Path, str, str]], int
             template = json.loads(tpl_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:
             print(f"  Warning: Could not parse {tpl_path.name}: {exc}", file=sys.stderr)
+            parse_errors += 1
             continue
 
         for logical_id, resource in template.get("Resources", {}).items():
@@ -131,7 +185,7 @@ def scan_templates(template_dir: Path) -> tuple[list[tuple[Path, str, str]], int
             if not is_valid_bucket_name(bucket_name):
                 violations.append((tpl_path, logical_id, bucket_name))
 
-    return violations, checked
+    return violations, checked, parse_errors
 
 
 def main() -> int:
@@ -161,6 +215,7 @@ def main() -> int:
         )
 
     total_violations = 0
+    total_parse_errors = 0
 
     if args.template_dir:
         tdir = Path(args.template_dir).resolve()
@@ -168,7 +223,8 @@ def main() -> int:
             print(f"Error: --template-dir not found: {tdir}", file=sys.stderr)
             return 1
         print(f"Scanning CloudFormation templates in {tdir} ...")
-        tpl_violations, tpl_checked = scan_templates(tdir)
+        tpl_violations, tpl_checked, tpl_parse_errors = scan_templates(tdir)
+        total_parse_errors += tpl_parse_errors
         if tpl_violations:
             total_violations += len(tpl_violations)
             print(f"\n{len(tpl_violations)} bucket name violation(s) in templates:\n")
@@ -187,7 +243,8 @@ def main() -> int:
             print(f"Error: --path not found: {root}", file=sys.stderr)
             return 1
         print(f"\nScanning {root} for S3 bucket_name= arguments...")
-        src_violations, src_checked = scan_directory(root)
+        src_violations, src_checked, src_parse_errors = scan_directory(root)
+        total_parse_errors += src_parse_errors
         print(
             f"   Found {src_checked} hardcoded bucket name(s) across all .py files.\n"
         )
@@ -211,6 +268,13 @@ def main() -> int:
 
     if total_violations > 0:
         return 1
+    if total_parse_errors > 0:
+        print(
+            f"Error: {total_parse_errors} file(s) could not be parsed — "
+            "scan incomplete.",
+            file=sys.stderr,
+        )
+        return 2
     if not args.quiet:
         print("All checked bucket names pass.")
     return 0

--- a/tests/test_check_no_public_access.py
+++ b/tests/test_check_no_public_access.py
@@ -34,8 +34,39 @@ class TestExtractPolicies:
                 }
             }
         }
-        result = cnpa.extract_policies(template)
-        assert result == [("BP", "AWS::S3::Bucket", {"Version": "2012-10-17"})]
+        policies, errors = cnpa.extract_policies(template)
+        assert policies == [("BP", "AWS::S3::Bucket", {"Version": "2012-10-17"})]
+        assert errors == []
+
+    def test_stringified_policy_parsed(self):
+        # CloudFormation allows policy documents serialized as JSON strings.
+        template = {
+            "Resources": {
+                "BP": {
+                    "Type": "AWS::S3::BucketPolicy",
+                    "Properties": {
+                        "PolicyDocument": json.dumps({"Version": "2012-10-17"})
+                    },
+                }
+            }
+        }
+        policies, errors = cnpa.extract_policies(template)
+        assert policies == [("BP", "AWS::S3::Bucket", {"Version": "2012-10-17"})]
+        assert errors == []
+
+    def test_unparseable_policy_string_reported(self):
+        template = {
+            "Resources": {
+                "BP": {
+                    "Type": "AWS::S3::BucketPolicy",
+                    "Properties": {"PolicyDocument": "{not json"},
+                }
+            }
+        }
+        policies, errors = cnpa.extract_policies(template)
+        assert policies == []
+        assert len(errors) == 1
+        assert errors[0][0] == "BP"
 
     def test_iam_role_excluded(self):
         # IAM::Role trust policies are intentionally not analyzed.
@@ -47,18 +78,18 @@ class TestExtractPolicies:
                 }
             }
         }
-        assert cnpa.extract_policies(template) == []
+        assert cnpa.extract_policies(template) == ([], [])
         assert "AWS::IAM::Role" not in cnpa.POLICY_MAP
 
     def test_resource_without_policy_skipped(self):
         template = {
             "Resources": {"BP": {"Type": "AWS::S3::BucketPolicy", "Properties": {}}}
         }
-        assert cnpa.extract_policies(template) == []
+        assert cnpa.extract_policies(template) == ([], [])
 
     def test_unknown_type_skipped(self):
         template = {"Resources": {"Fn": {"Type": "AWS::Lambda::Function"}}}
-        assert cnpa.extract_policies(template) == []
+        assert cnpa.extract_policies(template) == ([], [])
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +137,14 @@ class TestWriteSummary:
         summary = tmp_path / "summary.md"
         monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
         cnpa.write_summary(
-            [{"logical_id": "R", "resource_type": "AWS::S3::Bucket", "public": False, "reasons": []}],
+            [
+                {
+                    "logical_id": "R",
+                    "resource_type": "AWS::S3::Bucket",
+                    "public": False,
+                    "reasons": [],
+                }
+            ],
             "Stack.template.json",
         )
         text = summary.read_text()
@@ -166,6 +204,32 @@ class TestMain:
         monkeypatch.setattr(
             "sys.argv", ["prog", "--template-dir", str(tmp_path / "nope")]
         )
+        assert cnpa.main() == 1
+
+    def test_api_error_exits_two(self, tmp_path, monkeypatch):
+        self._template(tmp_path)
+        err = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "no perms"}},
+            "CheckNoPublicAccess",
+        )
+        monkeypatch.setattr(
+            cnpa.boto3, "client", lambda *a, **k: FakeClient(raises=err)
+        )
+        monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
+        assert cnpa.main() == 2
+
+    def test_malformed_template_exits_two(self, tmp_path, monkeypatch):
+        (tmp_path / "Stack.template.json").write_text("{not json")
+        monkeypatch.setattr(cnpa.boto3, "client", lambda *a, **k: FakeClient("PASS"))
+        monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
+        assert cnpa.main() == 2
+
+    def test_violation_takes_precedence_over_error(self, tmp_path, monkeypatch):
+        # One template fails to parse, another has a public policy → exit 1.
+        (tmp_path / "Broken.template.json").write_text("{not json")
+        self._template(tmp_path)
+        monkeypatch.setattr(cnpa.boto3, "client", lambda *a, **k: FakeClient("FAIL"))
+        monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
         assert cnpa.main() == 1
 
 

--- a/tests/test_validate_bucket_names.py
+++ b/tests/test_validate_bucket_names.py
@@ -24,9 +24,7 @@ class TestIsValidBucketName:
         assert not vbn.is_valid_bucket_name("bitwarden-12345-us-east-1-an")
 
     def test_underscore_in_prefix(self):
-        assert not vbn.is_valid_bucket_name(
-            "bitwarden_logs-123456789012-us-east-1-an"
-        )
+        assert not vbn.is_valid_bucket_name("bitwarden_logs-123456789012-us-east-1-an")
 
     def test_uppercase_rejected(self):
         assert not vbn.is_valid_bucket_name("Bitwarden-123456789012-us-east-1-an")
@@ -53,17 +51,51 @@ class TestExtractBucketNames:
             )
         )
         found = vbn.extract_bucket_names_from_file(src)
-        assert [name for _, name in found] == ["logs-123456789012-us-east-1-an"]
+        assert [(name, valid) for _, name, valid in found] == [
+            ("logs-123456789012-us-east-1-an", True)
+        ]
+
+    def test_invalid_literal_marked(self, tmp_path):
+        src = tmp_path / "stack.py"
+        # Built indirectly so this test file itself never contains a
+        # non-conforming bucket_name= literal.
+        src.write_text('s3.Bucket(self, "B", bucket_name=%s)\n' % '"my-bucket"')
+        found = vbn.extract_bucket_names_from_file(src)
+        assert [(name, valid) for _, name, valid in found] == [("my-bucket", False)]
 
     def test_ignores_other_kwargs(self, tmp_path):
         src = tmp_path / "stack.py"
         src.write_text('s3.Bucket(self, "B", versioned=True)\n')
         assert vbn.extract_bucket_names_from_file(src) == []
 
-    def test_syntax_error_returns_empty(self, tmp_path):
+    def test_syntax_error_raises(self, tmp_path):
+        import pytest
+
         src = tmp_path / "broken.py"
         src.write_text("def (:\n")  # invalid syntax
-        assert vbn.extract_bucket_names_from_file(src) == []
+        with pytest.raises(SyntaxError):
+            vbn.extract_bucket_names_from_file(src)
+
+    def test_conforming_fstring_passes(self, tmp_path):
+        src = tmp_path / "stack.py"
+        src.write_text('B(bucket_name=f"logs-{account_id}-{region}-an")\n')
+        found = vbn.extract_bucket_names_from_file(src)
+        assert len(found) == 1
+        _, display, valid = found[0]
+        assert valid
+        assert display == "logs-{account_id}-{region}-an"
+
+    def test_fstring_missing_suffix_flagged(self, tmp_path):
+        src = tmp_path / "stack.py"
+        src.write_text('B(bucket_name=f"logs-{account_id}-{region}")\n')
+        found = vbn.extract_bucket_names_from_file(src)
+        assert [valid for _, _, valid in found] == [False]
+
+    def test_fstring_bad_literal_chars_flagged(self, tmp_path):
+        src = tmp_path / "stack.py"
+        src.write_text('B(bucket_name=f"My_Logs-{account_id}-{region}-an")\n')
+        found = vbn.extract_bucket_names_from_file(src)
+        assert [valid for _, _, valid in found] == [False]
 
 
 # ---------------------------------------------------------------------------
@@ -75,18 +107,27 @@ class TestScanDirectory:
             'B(bucket_name="logs-123456789012-us-east-1-an")\n'
         )
         (tmp_path / "bad.py").write_text('B(bucket_name="my-bucket")\n')
-        violations, checked = vbn.scan_directory(tmp_path)
+        violations, checked, parse_errors = vbn.scan_directory(tmp_path)
         assert checked == 2
         assert len(violations) == 1
         assert violations[0][2] == "my-bucket"
+        assert parse_errors == 0
 
     def test_excludes_vendored_dirs(self, tmp_path):
         venv = tmp_path / ".venv"
         venv.mkdir()
         (venv / "dep.py").write_text('B(bucket_name="my-bucket")\n')
-        violations, checked = vbn.scan_directory(tmp_path)
+        violations, checked, parse_errors = vbn.scan_directory(tmp_path)
         assert checked == 0
         assert violations == []
+        assert parse_errors == 0
+
+    def test_unparseable_file_counted(self, tmp_path):
+        (tmp_path / "broken.py").write_text("def (:\n")
+        violations, checked, parse_errors = vbn.scan_directory(tmp_path)
+        assert violations == []
+        assert checked == 0
+        assert parse_errors == 1
 
 
 # ---------------------------------------------------------------------------
@@ -97,13 +138,17 @@ class TestScanTemplates:
         props = {} if bucket_name is None else {"BucketName": bucket_name}
         path.write_text(
             json.dumps(
-                {"Resources": {"Bucket": {"Type": "AWS::S3::Bucket", "Properties": props}}}
+                {
+                    "Resources": {
+                        "Bucket": {"Type": "AWS::S3::Bucket", "Properties": props}
+                    }
+                }
             )
         )
 
     def test_flags_invalid_template_name(self, tmp_path):
         self._write_template(tmp_path / "Stack.template.json", "my-bucket")
-        violations, checked = vbn.scan_templates(tmp_path)
+        violations, checked, parse_errors = vbn.scan_templates(tmp_path)
         assert checked == 1
         assert len(violations) == 1
 
@@ -111,14 +156,14 @@ class TestScanTemplates:
         self._write_template(
             tmp_path / "Stack.template.json", "logs-123456789012-us-east-1-an"
         )
-        violations, checked = vbn.scan_templates(tmp_path)
+        violations, checked, parse_errors = vbn.scan_templates(tmp_path)
         assert checked == 1
         assert violations == []
 
     def test_autogenerated_name_skipped(self, tmp_path):
         # No BucketName property -> auto-named, not checked.
         self._write_template(tmp_path / "Stack.template.json", None)
-        violations, checked = vbn.scan_templates(tmp_path)
+        violations, checked, parse_errors = vbn.scan_templates(tmp_path)
         assert checked == 0
 
     def test_intrinsic_bucketname_skipped(self, tmp_path):
@@ -135,14 +180,21 @@ class TestScanTemplates:
                 }
             )
         )
-        violations, checked = vbn.scan_templates(tmp_path)
+        violations, checked, parse_errors = vbn.scan_templates(tmp_path)
         assert checked == 0
 
     def test_manifest_and_asset_skipped(self, tmp_path):
         self._write_template(tmp_path / "manifest.json", "my-bucket")
         self._write_template(tmp_path / "asset.abc.template.json", "my-bucket")
-        violations, checked = vbn.scan_templates(tmp_path)
+        violations, checked, parse_errors = vbn.scan_templates(tmp_path)
         assert checked == 0
+
+    def test_malformed_template_counted(self, tmp_path):
+        (tmp_path / "Stack.template.json").write_text("{not json")
+        violations, checked, parse_errors = vbn.scan_templates(tmp_path)
+        assert violations == []
+        assert checked == 0
+        assert parse_errors == 1
 
 
 # ---------------------------------------------------------------------------
@@ -167,3 +219,14 @@ class TestMain:
         monkeypatch.setattr("sys.argv", ["prog"])
         with pytest.raises(SystemExit):
             vbn.main()
+
+    def test_exit_two_on_unparseable_file(self, tmp_path, monkeypatch):
+        (tmp_path / "broken.py").write_text("def (:\n")
+        monkeypatch.setattr("sys.argv", ["prog", "--path", str(tmp_path)])
+        assert vbn.main() == 2
+
+    def test_violation_takes_precedence_over_parse_error(self, tmp_path, monkeypatch):
+        (tmp_path / "broken.py").write_text("def (:\n")
+        (tmp_path / "bad.py").write_text("B(bucket_name=%s)\n" % '"my-bucket"')
+        monkeypatch.setattr("sys.argv", ["prog", "--path", str(tmp_path)])
+        assert vbn.main() == 1


### PR DESCRIPTION
## Summary

Closes the script-robustness gaps from the June 2026 review — all three were silent-false-negative paths.

### `scripts/validate_bucket_names.py`
- **f-strings are now validated** (best-effort): `bucket_name=f"logs-{acct}-{region}-an"` was previously skipped entirely. Literal parts must be kebab-case and the name must end with a literal `-an` suffix; interpolated expressions are displayed as `{expr}` placeholders in violation output.
- **Unparseable files fail the scan**: a `SyntaxError` in a caller's `.py` file or malformed template JSON previously passed silently. Now counted and reported; the script exits **2** for an incomplete scan (violations still exit 1 and take precedence).

### `scripts/check_no_public_access.py`
- **Stringified policy documents** (`"PolicyDocument": "{...json...}"` — valid CloudFormation) are now parsed instead of being passed through `json.dumps` as a quoted string.
- **Errors no longer pass silently**: template parse failures, unparseable policy strings, and Access Analyzer `ClientError`s (e.g. AccessDenied) previously resulted in `public: false` / a warning and exit 0. Now counted; the script exits **2** when any check could not be completed.

### Exit-code contract (both scripts)
| Code | Meaning |
|---|---|
| 0 | all checks passed |
| 1 | violations found |
| 2 | scan incomplete (parse/API errors, no violations otherwise) |

Workflows consuming these scripts fail the job on any nonzero exit, so callers now fail loudly instead of getting a green check from an unchecked template.

## Testing

- 48 tests pass (`pytest tests/ -q`), 13 new: f-string pass/fail cases, parse-error counting, stringified/unparseable policies, exit-code precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)