### PR TITLE
chore: P1 cleanup — backup consolidation, ship-logs, cdk-review, self-test linting

### DIFF
--- a/.github/actions/ship-logs/action.yml
+++ b/.github/actions/ship-logs/action.yml
@@ -121,11 +121,12 @@ runs:
         log_stream = os.environ["LOG_STREAM"]
         region     = os.environ["AWS_REGION"]
 
-        sequence_token = None
-
         def put_events(events):
-            """Send a batch of events to CloudWatch, returning the next sequence token."""
-            global sequence_token
+            """Send a batch of events to CloudWatch.
+
+            Sequence tokens are not needed: CloudWatch has ignored
+            --sequence-token since Aug 2023.
+            """
             if not events:
                 return
             events_file = Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "cw-events.json"
@@ -137,15 +138,8 @@ runs:
                 "--log-events", f"file://{events_file}",
                 "--region", region,
             ]
-            if sequence_token:
-                cmd += ["--sequence-token", sequence_token]
             result = subprocess.run(cmd, capture_output=True, text=True)
-            if result.returncode == 0:
-                try:
-                    sequence_token = json.loads(result.stdout).get("nextSequenceToken")
-                except (json.JSONDecodeError, AttributeError):
-                    pass
-            else:
+            if result.returncode != 0:
                 print(f"Warning: put-log-events failed: {result.stderr.strip()}", file=sys.stderr)
 
         # Process each log file

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,5 +1,7 @@
 name: Backup to S3
 
+# Weekly self-backup. Thin wrapper over the reusable repo-backup workflow —
+# all backup logic lives in repo-backup.yml.
 on:
   schedule:
     - cron: "0 2 * * 0"  # weekly, Sunday 02:00 UTC
@@ -7,52 +9,12 @@ on:
 
 jobs:
   backup:
-    name: Backup to S3
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: production
+    uses: ./.github/workflows/repo-backup.yml
+    secrets: inherit
     permissions:
       id-token: write
       contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Resolve inputs
-        id: vars
-        run: |
-          REPO_NAME="${{ github.event.repository.name }}"
-          DATE=$(date -u +%Y-%m-%d)
-          SHA="${{ github.sha }}"
-          FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
-          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
-          echo "s3-key=${REPO_NAME}/${FILENAME}" >> "$GITHUB_OUTPUT"
-
-      - name: Create zip archive
-        run: |
-          git archive --format=zip --output="${{ steps.vars.outputs.filename }}" HEAD
-          SIZE=$(du -sh "${{ steps.vars.outputs.filename }}" | cut -f1)
-          echo "ARCHIVE_SIZE=$SIZE" >> "$GITHUB_ENV"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Upload to S3
-        run: |
-          aws s3 cp "${{ steps.vars.outputs.filename }}" \
-            "s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}"
-
-      - name: Write job summary
-        run: |
-          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| S3 URI | \`s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"
+    with:
+      # BACKUP_S3_BUCKET is a repository-level variable.
+      s3-bucket: ${{ vars.BACKUP_S3_BUCKET }}
+      environment: backup

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -16,7 +16,10 @@ name: CDK Review
         type: string
         default: ""
       smoke-test-url:
-        description: URL to curl after deploy (optional)
+        # Unused — kept for caller interface parity with cdk-deploy, and
+        # because at least one caller passes it (removing the input would
+        # break their workflow_call).
+        description: Unused — accepted for interface parity with cdk-deploy
         type: string
         default: ""
       enable-access-analyzer:
@@ -76,10 +79,11 @@ jobs:
         with:
           cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
+      # setup-cdk already installs requirements.txt; only dev deps are
+      # installed here.
+      - name: Install dev dependencies
+        if: hashFiles('requirements-dev.txt') != ''
+        run: pip install -r requirements-dev.txt
 
       - name: Lint (ruff)
         if: hashFiles('requirements-dev.txt') != '' && success()

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -30,5 +30,21 @@ jobs:
       - name: Lint YAML (yamllint)
         run: yamllint -c .yamllint.yml .github/
 
+      - name: Lint Python (ruff)
+        run: ruff check scripts/ tests/
+
+      - name: SAST scan (bandit)
+        run: bandit -r scripts/ -ll -q
+
+      - name: Lint workflows (actionlint)
+        run: |
+          # Download script pinned to the v1.7.12 tag's commit SHA.
+          bash <(curl -sSfL "https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash") 1.7.12 "$RUNNER_TEMP"
+          # -shellcheck= disables shellcheck integration (style noise on
+          # intentional unquoted expansions). The -ignore covers
+          # job.workflow_sha, which is valid but missing from actionlint's
+          # context model as of 1.7.12.
+          "$RUNNER_TEMP/actionlint" -shellcheck= -ignore 'property "workflow_sha" is not defined'
+
       - name: Run tests (pytest)
         run: pytest tests/ -v

--- a/.github/workflows/validate-bucket-names.yml
+++ b/.github/workflows/validate-bucket-names.yml
@@ -36,6 +36,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: Specter099/.github
+          # Pin the scripts to the same commit this reusable workflow was
+          # loaded from, so workflow and scripts always move together
+          # instead of the scripts floating on main independently.
+          ref: ${{ job.workflow_sha }}
           path: .shared-github
 
       - name: Setup Python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@
 pytest>=8.0
 boto3>=1.34
 yamllint>=1.35
+ruff>=0.6
+bandit>=1.7


### PR DESCRIPTION
## Summary

Closes the remaining **P1** items from [TODO.md](https://github.com/Specter099/.github/blob/main/TODO.md) plus the opportunistic self-test improvements.

- **`backup.yml` → thin wrapper over `repo-backup.yml`** — ~60 lines of duplicated backup logic deleted. Now runs in the `backup` environment (verified it exists with `AWS_ROLE_ARN`) instead of `production`, and `BACKUP_S3_BUCKET` is a repo-level variable so it resolves at the caller level.
- **`ship-logs`** — removed the dead CloudWatch `sequence_token` plumbing (`--sequence-token` has been ignored by the API since Aug 2023).
- **`cdk-review.yml`** — dropped the redundant `pip install -r requirements.txt` (the `setup-cdk` composite already installs it); dev deps now install via `hashFiles` condition instead of `&& ... || true` (which masked install failures); `smoke-test-url` documented as unused but **kept** — bitwarden-cdk passes it, so removing the input would break that caller's `workflow_call`.
- **`validate-bucket-names.yml`** — the shared-scripts checkout is now pinned to `${{ job.workflow_sha }}` (the commit the reusable workflow itself was loaded from), so scripts and workflow always move together instead of scripts floating on `main` independently. Verified `job.workflow_sha` against current GitHub docs.
- **`self-test.yml`** — now also runs `ruff check`, `bandit -ll`, and `actionlint` (download script pinned to the v1.7.12 tag commit; shellcheck integration disabled to avoid style noise on intentional unquoted expansions). `ruff`/`bandit` added to `requirements-dev.txt`.

Note: `ruff format --check` deliberately not added yet — the test files get reformatted in #85; it can be enabled after that lands.

## Testing

- `yamllint`, `actionlint`, `ruff check`, `bandit`, and `pytest` (35 passed) all green locally with the exact commands self-test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)