### PR TITLE
fix(access-analyzer): resolve CFN intrinsics before CheckNoPublicAccess

### DIFF
--- a/scripts/check_no_public_access.py
+++ b/scripts/check_no_public_access.py
@@ -21,6 +21,76 @@ from pathlib import Path
 import boto3
 from botocore.exceptions import ClientError
 
+
+def partition_for_region(region: str) -> str:
+    if region.startswith("us-gov-"):
+        return "aws-us-gov"
+    if region.startswith("cn-"):
+        return "aws-cn"
+    return "aws"
+
+
+def resolve_intrinsics(node, ctx):
+    """Best-effort resolution of CloudFormation pseudo-parameters and intrinsics
+    to literal values, so CheckNoPublicAccess receives a valid policy document.
+
+    CDK-synthesized policies routinely contain ``Fn::Join``, ``Fn::Sub``,
+    ``Fn::GetAtt`` and ``Ref`` to ``AWS::Partition``/``AWS::AccountId`` etc.
+    CheckNoPublicAccess rejects these with "policy in policyDocument is invalid",
+    which previously made every KMS-key / bucket-policy scan fail as incomplete.
+
+    Public-access is determined solely by ``Principal`` (and ``Condition``).
+    Pseudo-parameters are resolved exactly; any remaining ``Ref``/``Fn::GetAtt``
+    to a resource becomes a harmless placeholder ARN (never ``"*"``), so a
+    genuinely public ``Principal: "*"`` is still detected while the document
+    becomes syntactically valid.
+    """
+    pseudo = {
+        "AWS::Partition": ctx["partition"],
+        "AWS::Region": ctx["region"],
+        "AWS::AccountId": ctx["account"],
+        "AWS::URLSuffix": ctx["url_suffix"],
+    }
+    if isinstance(node, dict):
+        if len(node) == 1:
+            ((key, val),) = node.items()
+            if key == "Ref":
+                if isinstance(val, str) and val in pseudo:
+                    return pseudo[val]
+                return (
+                    f"arn:{ctx['partition']}:placeholder:{ctx['region']}:"
+                    f"{ctx['account']}:{val}"
+                )
+            if key == "Fn::Join" and isinstance(val, list) and len(val) == 2:
+                sep, parts = val
+                resolved = [resolve_intrinsics(p, ctx) for p in parts]
+                if all(isinstance(p, str) for p in resolved):
+                    return sep.join(resolved)
+                return node
+            if key == "Fn::Sub":
+                template, varmap = (
+                    (val[0], val[1]) if isinstance(val, list) else (val, {})
+                )
+                out = template
+                substitutions = dict(pseudo)
+                for name, value in varmap.items():
+                    resolved = resolve_intrinsics(value, ctx)
+                    substitutions[name] = resolved if isinstance(resolved, str) else ""
+                for name, value in substitutions.items():
+                    out = out.replace("${" + name + "}", value)
+                return out
+            if key == "Fn::GetAtt":
+                logical = val[0] if isinstance(val, list) else str(val)
+                return (
+                    f"arn:{ctx['partition']}:placeholder:{ctx['region']}:"
+                    f"{ctx['account']}:{logical}"
+                )
+        return {k: resolve_intrinsics(v, ctx) for k, v in node.items()}
+    if isinstance(node, list):
+        return [resolve_intrinsics(v, ctx) for v in node]
+    return node
+
+
 # Maps CloudFormation resource type → (policy property, Access Analyzer resource type)
 POLICY_MAP = {
     "AWS::S3::BucketPolicy": ("PolicyDocument", "AWS::S3::Bucket"),
@@ -81,11 +151,14 @@ def extract_policies(
     return results, errors
 
 
-def check_policy(client, logical_id: str, analyzer_type: str, policy_doc: dict) -> dict:
+def check_policy(
+    client, logical_id: str, analyzer_type: str, policy_doc: dict, ctx: dict
+) -> dict:
     """Call CheckNoPublicAccess and return a result dict."""
     try:
+        resolved = resolve_intrinsics(policy_doc, ctx)
         resp = client.check_no_public_access(
-            policyDocument=json.dumps(policy_doc),
+            policyDocument=json.dumps(resolved),
             resourceType=analyzer_type,
         )
         is_public = resp.get("result") == "FAIL"
@@ -174,6 +247,18 @@ def main() -> int:
 
     client = boto3.client("accessanalyzer", region_name=args.aws_region)
 
+    # Context for resolving CloudFormation pseudo-parameters to literals.
+    try:
+        account = boto3.client("sts").get_caller_identity()["Account"]
+    except ClientError:
+        account = "000000000000"
+    ctx = {
+        "partition": partition_for_region(args.aws_region),
+        "region": args.aws_region,
+        "account": account,
+        "url_suffix": "amazonaws.com",
+    }
+
     total_violations = 0
     total_errors = 0
 
@@ -199,7 +284,7 @@ def main() -> int:
 
         findings = []
         for logical_id, analyzer_type, policy_doc in policies:
-            result = check_policy(client, logical_id, analyzer_type, policy_doc)
+            result = check_policy(client, logical_id, analyzer_type, policy_doc, ctx)
             findings.append(result)
 
             if "error" in result:


### PR DESCRIPTION
## Problem

The IAM Access Analyzer check (`scripts/check_no_public_access.py`, used by the shared `access-analyzer` action and `cdk-review` workflow, both pinned to `@main`) fails on **every** repo whose synthesized templates contain KMS keys or bucket policies:

```
⚠  FlowLogsKmsKey (AWS::KMS::Key) — error: ValidationException: The policy in policyDocument is invalid.
⚠  EbsKmsKey (AWS::KMS::Key) — error: ValidationException: The policy in policyDocument is invalid.
⚠  CloudFrontLogsBucketPolicy (AWS::S3::Bucket) — error: ValidationException: The policy in policyDocument is invalid.
3 template(s)/resource(s) could not be checked — scan incomplete   →  exit 2
```

**Root cause:** the script passes the raw CloudFormation policy to `CheckNoPublicAccess`, but CDK synthesizes intrinsics into nearly every policy — e.g. the default KMS key policy's root principal is `{"Fn::Join": ["", ["arn:", {"Ref": "AWS::Partition"}, ":iam::<acct>:root"]]}`. `CheckNoPublicAccess` only accepts a literal policy, so it rejects these as invalid. The resources are **not public** — they just couldn't be evaluated.

This surfaced on [bitwarden-cdk#45](https://github.com/Specter099/bitwarden-cdk/pull/45). It was latent because bitwarden's `security.yml` was switched to PR-only in #33, so `main` hadn't re-run the check since this script last changed; #45 was the first PR since.

## Fix

Add `resolve_intrinsics()`, applied to each policy before the API call:

- Resolve pseudo-parameters exactly: `AWS::Partition`, `AWS::Region`, `AWS::AccountId` (via STS), `AWS::URLSuffix`
- Flatten `Fn::Join` and `Fn::Sub`
- Replace any remaining `Ref`/`Fn::GetAtt` to a resource with a harmless placeholder ARN

Public access is determined solely by `Principal`/`Condition`, so a literal `Principal: "*"` is never altered — detection is fully preserved.

## Testing

Against bitwarden-cdk's synth output:

| | before | after |
|---|---|---|
| FlowLogsKmsKey | ⚠ invalid | ✓ PASS |
| EbsKmsKey | ⚠ invalid | ✓ PASS |
| CloudFrontLogsBucketPolicy | ⚠ invalid | ✓ PASS |
| **exit code** | **2** | **0** |

Negative test — a public `Allow` with `Principal: "*"` wrapped in `Fn::Join`/`Fn::GetAtt` still returns **FAIL → exit 1**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)