### PR TITLE
fix: allow template-dir to be skipped for non-CDK repos

### DIFF
--- a/.github/actions/access-analyzer/action.yml
+++ b/.github/actions/access-analyzer/action.yml
@@ -5,7 +5,9 @@ description: >
 
 inputs:
   template-dir:
-    description: Directory containing CloudFormation *.template.json files
+    description: >
+      Directory containing CDK-synthesized CloudFormation *.template.json files.
+      Leave empty to skip (e.g. repos with no CDK app — use yaml-template-dir instead).
     default: cdk.out
   yaml-template-dir:
     description: >
@@ -55,8 +57,10 @@ runs:
         [ "$FAIL_ON_PUBLIC_ACCESS" = "true" ] || FAIL_FLAG="--no-fail-on-public-access"
 
         rc=0
-        python3 "$SCRIPT" --template-dir "$TEMPLATE_DIR" \
-          --aws-region "$AWS_REGION" "$FAIL_FLAG" || rc=$?
+        if [ -n "$TEMPLATE_DIR" ]; then
+          python3 "$SCRIPT" --template-dir "$TEMPLATE_DIR" \
+            --aws-region "$AWS_REGION" "$FAIL_FLAG" || rc=$?
+        fi
         if [ -n "$YAML_TEMPLATE_DIR" ]; then
           python3 "$SCRIPT" --template-dir "$YAML_TEMPLATE_DIR" \
             --aws-region "$AWS_REGION" "$FAIL_FLAG" || rc=$?

--- a/.github/workflows/access-analyzer-check.yml
+++ b/.github/workflows/access-analyzer-check.yml
@@ -8,7 +8,9 @@ on:
         type: string
         default: us-east-1
       template-dir:
-        description: Directory containing CloudFormation *.template.json files (e.g. cdk.out)
+        description: >-
+          Directory containing CDK-synthesized CloudFormation *.template.json files.
+          Leave empty to skip (e.g. repos with no CDK app — use yaml-template-dir instead).
         type: string
         default: cdk.out
       yaml-template-dir:

--- a/tests/test_check_no_public_access.py
+++ b/tests/test_check_no_public_access.py
@@ -107,15 +107,39 @@ class FakeClient:
         return {"result": self._result, "reasons": self._reasons}
 
 
+class FakeStsClient:
+    def get_caller_identity(self):
+        return {"Account": "123456789012"}
+
+
+def fake_boto3_client(accessanalyzer_client):
+    """boto3.client stub that dispatches on service name, like main() expects."""
+
+    def _client(service_name, *args, **kwargs):
+        if service_name == "sts":
+            return FakeStsClient()
+        return accessanalyzer_client
+
+    return _client
+
+
+FAKE_CTX = {
+    "partition": "aws",
+    "region": "us-east-1",
+    "account": "123456789012",
+    "url_suffix": "amazonaws.com",
+}
+
+
 class TestCheckPolicy:
     def test_pass(self):
-        r = cnpa.check_policy(FakeClient("PASS"), "R", "AWS::S3::Bucket", {})
+        r = cnpa.check_policy(FakeClient("PASS"), "R", "AWS::S3::Bucket", {}, FAKE_CTX)
         assert r["public"] is False
         assert "error" not in r
 
     def test_fail_with_reasons(self):
         client = FakeClient("FAIL", reasons=[{"description": "anyone can read"}])
-        r = cnpa.check_policy(client, "R", "AWS::S3::Bucket", {})
+        r = cnpa.check_policy(client, "R", "AWS::S3::Bucket", {}, FAKE_CTX)
         assert r["public"] is True
         assert r["reasons"] == ["anyone can read"]
 
@@ -124,7 +148,9 @@ class TestCheckPolicy:
             {"Error": {"Code": "ValidationException", "Message": "bad policy"}},
             "CheckNoPublicAccess",
         )
-        r = cnpa.check_policy(FakeClient(raises=err), "R", "AWS::S3::Bucket", {})
+        r = cnpa.check_policy(
+            FakeClient(raises=err), "R", "AWS::S3::Bucket", {}, FAKE_CTX
+        )
         assert r["public"] is False
         assert "ValidationException" in r["error"]
 
@@ -181,13 +207,13 @@ class TestMain:
 
     def test_public_access_exits_one(self, tmp_path, monkeypatch):
         self._template(tmp_path)
-        monkeypatch.setattr(cnpa.boto3, "client", lambda *a, **k: FakeClient("FAIL"))
+        monkeypatch.setattr(cnpa.boto3, "client", fake_boto3_client(FakeClient("FAIL")))
         monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
         assert cnpa.main() == 1
 
     def test_public_access_warn_only_exits_zero(self, tmp_path, monkeypatch):
         self._template(tmp_path)
-        monkeypatch.setattr(cnpa.boto3, "client", lambda *a, **k: FakeClient("FAIL"))
+        monkeypatch.setattr(cnpa.boto3, "client", fake_boto3_client(FakeClient("FAIL")))
         monkeypatch.setattr(
             "sys.argv",
             ["prog", "--template-dir", str(tmp_path), "--no-fail-on-public-access"],
@@ -196,7 +222,7 @@ class TestMain:
 
     def test_all_pass_exits_zero(self, tmp_path, monkeypatch):
         self._template(tmp_path)
-        monkeypatch.setattr(cnpa.boto3, "client", lambda *a, **k: FakeClient("PASS"))
+        monkeypatch.setattr(cnpa.boto3, "client", fake_boto3_client(FakeClient("PASS")))
         monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
         assert cnpa.main() == 0
 
@@ -213,14 +239,14 @@ class TestMain:
             "CheckNoPublicAccess",
         )
         monkeypatch.setattr(
-            cnpa.boto3, "client", lambda *a, **k: FakeClient(raises=err)
+            cnpa.boto3, "client", fake_boto3_client(FakeClient(raises=err))
         )
         monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
         assert cnpa.main() == 2
 
     def test_malformed_template_exits_two(self, tmp_path, monkeypatch):
         (tmp_path / "Stack.template.json").write_text("{not json")
-        monkeypatch.setattr(cnpa.boto3, "client", lambda *a, **k: FakeClient("PASS"))
+        monkeypatch.setattr(cnpa.boto3, "client", fake_boto3_client(FakeClient("PASS")))
         monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
         assert cnpa.main() == 2
 
@@ -228,7 +254,7 @@ class TestMain:
         # One template fails to parse, another has a public policy → exit 1.
         (tmp_path / "Broken.template.json").write_text("{not json")
         self._template(tmp_path)
-        monkeypatch.setattr(cnpa.boto3, "client", lambda *a, **k: FakeClient("FAIL"))
+        monkeypatch.setattr(cnpa.boto3, "client", fake_boto3_client(FakeClient("FAIL")))
         monkeypatch.setattr("sys.argv", ["prog", "--template-dir", str(tmp_path)])
         assert cnpa.main() == 1
 


### PR DESCRIPTION
## Summary

`check_no_public_access.py` correctly hard-fails when a requested `template-dir` doesn't exist (catches forgetting to run `cdk synth`) — that's intentional, tested behavior. But `access-analyzer-check.yml` defaults `template-dir` to `cdk.out` unconditionally, with no way to opt out, unlike `yaml-template-dir` which already supports an empty string to skip.

Any caller repo with no CDK app (YAML-only CloudFormation, e.g. `github-oidc-stackset-template`) fails this check on every run, since `cdk.out` never exists there. Confirmed via `github-oidc-stackset-template`'s CI history: every prior run passed only because the old inline composite-action Python (pre-#73) silently treated a missing/empty `TEMPLATE_DIR` as "no templates found." #73 replaced that with the shared, stricter `check_no_public_access.py`, which started hard-failing — it just hadn't run on that repo since the change landed until now.

## Changes

- `template-dir` input can now be set to `""` to skip the CDK-template check entirely, mirroring the existing `yaml-template-dir` convention. Default stays `cdk.out`, so every existing CDK-repo caller is unaffected.
- **Also fixes a pre-existing, unrelated break in this repo's own test suite** found while verifying this PR: #90 added a `ctx` parameter to `check_policy()` and a `boto3.client("sts")` call inside `main()`, but didn't update `tests/test_check_no_public_access.py` — the `boto3.client` monkeypatch returned the same `FakeClient` for every service name, so the new `sts` call hit a mock lacking `get_caller_identity`, and `check_policy()` calls were missing the new `ctx` arg. 9 tests broke silently (confirmed still broken on `main` independent of this PR). Added a dispatching `boto3.client` stub and a `FAKE_CTX` fixture.

## Testing

- `pytest tests/` → 48 passed (was 39 passed / 9 failed before the mock fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)