### PR TITLE
Add Docker Buildx and QEMU setup to static-site-deploy workflow

### DIFF
--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -108,6 +108,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: CDK Deploy
         working-directory: ${{ inputs.infra-dir }}
         env:


### PR DESCRIPTION
## Summary
Adds Docker build infrastructure setup steps to the `static-site-deploy` workflow to enable multi-platform container builds, specifically ARM64 support.

## Changes
- Added `docker/setup-qemu-action@v3` step to configure QEMU for ARM64 emulation
- Added `docker/setup-buildx-action@v3` step to set up Docker Buildx for advanced build capabilities
- Both steps are positioned before the CDK Deploy step to ensure build infrastructure is ready

## Details
These steps enable the workflow to build and push Docker images for multiple architectures (including ARM64) if needed during the CDK deployment phase. This is a prerequisite for any Docker image building that may occur in the infrastructure code.

https://claude.ai/code/session_01TTrTpzonXReJmxhr1jwbkN