### PR TITLE
Add org-wide default pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Infrastructure / CI change
+- [ ] Documentation
+
+## Checklist
+
+- [ ] I have tested these changes locally (or explained why that isn't possible)
+- [ ] I have updated documentation where relevant
+- [ ] CI checks (lint, tests, synth/diff, security scans) pass
+- [ ] No secrets, credentials, or account IDs are hardcoded
+
+## Related issues
+
+<!-- Link related issues, e.g. "Closes #123" -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ python scripts/check_no_public_access.py --template-dir /path/to/cdk.out
   actions/
     setup-cdk/action.yml      # Composite: Python 3.12 + Node 22 + CDK CLI
     access-analyzer/action.yml # Composite: scan CFN templates for public access
+  PULL_REQUEST_TEMPLATE.md    # Org-wide default PR template (applies to any repo without its own)
 scripts/
   check_no_public_access.py   # CLI for IAM Access Analyzer CheckNoPublicAccess API
   validate_bucket_names.py    # AST-based S3 bucket_name= convention checker

--- a/README.md
+++ b/README.md
@@ -213,3 +213,9 @@ Installs Python 3.12, Node 22, a pinned CDK CLI version globally, and Python dep
     cdk-version: "2.1106.1"
     requirements-path: infra/requirements.txt
 ```
+
+---
+
+## Default PR Template
+
+[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) in this repo is picked up by GitHub as the **org-wide default pull request template**. Any repo in the `Specter099` org that doesn't define its own `.github/pull_request_template.md` will use it automatically — no per-repo setup required.


### PR DESCRIPTION
Adds .github/PULL_REQUEST_TEMPLATE.md so GitHub auto-applies it to any
repo in the org that doesn't define its own PR template, matching the
reusable-workflow pattern already used here.