### PR TITLE
ci: harden workflows and fix review-gating bugs

### DIFF
--- a/.github/workflows/access-analyzer-check.yml
+++ b/.github/workflows/access-analyzer-check.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -18,21 +18,25 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve inputs
         id: vars
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          SHA: ${{ github.sha }}
         run: |
-          REPO_NAME="${{ github.event.repository.name }}"
           DATE=$(date -u +%Y-%m-%d)
-          SHA="${{ github.sha }}"
           FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
           echo "s3-key=${REPO_NAME}/${FILENAME}" >> "$GITHUB_OUTPUT"
 
       - name: Create zip archive
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
         run: |
-          git archive --format=zip --output="${{ steps.vars.outputs.filename }}" HEAD
-          SIZE=$(du -sh "${{ steps.vars.outputs.filename }}" | cut -f1)
+          git archive --format=zip --output="$FILENAME" HEAD
+          SIZE=$(du -sh "$FILENAME" | cut -f1)
           echo "ARCHIVE_SIZE=$SIZE" >> "$GITHUB_ENV"
 
       - name: Configure AWS credentials
@@ -42,17 +46,28 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload to S3
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ vars.BACKUP_S3_BUCKET }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          aws s3 cp "${{ steps.vars.outputs.filename }}" \
-            "s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}"
+          aws s3 cp "$FILENAME" "s3://${S3_BUCKET}/${S3_KEY}"
 
       - name: Write job summary
+        env:
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ vars.BACKUP_S3_BUCKET }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| S3 URI | \`s3://${{ vars.BACKUP_S3_BUCKET }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Repo Backup"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Repository | \`${REPOSITORY}\` |"
+            echo "| Commit | \`${SHA}\` |"
+            echo "| Archive | \`${FILENAME}\` |"
+            echo "| Size | $ARCHIVE_SIZE |"
+            echo "| S3 URI | \`s3://${S3_BUCKET}/${S3_KEY}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -62,6 +62,8 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Init CI log directory
         if: ${{ inputs.enable-ci-logs }}
@@ -135,15 +137,16 @@ jobs:
       - name: Smoke test
         if: ${{ inputs.smoke-test-url != '' }}
         env:
+          SMOKE_TEST_URL: ${{ inputs.smoke-test-url }}
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
           set -o pipefail
           _run_smoke() {
             status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 \
-              "${{ inputs.smoke-test-url }}" || echo "000")
+              "$SMOKE_TEST_URL" || echo "000")
             echo "Smoke test HTTP status: $status"
             echo "## Smoke Test" >> "$GITHUB_STEP_SUMMARY"
-            echo "Response from \`${{ inputs.smoke-test-url }}\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
+            echo "Response from \`$SMOKE_TEST_URL\`: **HTTP $status**" >> "$GITHUB_STEP_SUMMARY"
             if [[ "$status" == "000" ]]; then
               echo "::warning::Smoke test: curl failed or timed out"
             else
@@ -183,7 +186,7 @@ jobs:
               'actor': os.environ['META_ACTOR'],
               'event': os.environ['META_EVENT'],
               'job_status': os.environ['META_JOB_STATUS'],
-              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+              'timestamp': datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
           with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
               json.dump(meta, f, indent=2)

--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -16,7 +16,9 @@ name: CDK Review
         type: string
         default: ""
       smoke-test-url:
-        description: URL to curl after deploy (optional)
+        description: >-
+          Unused in review — accepted for interface consistency with the
+          deploy workflow
         type: string
         default: ""
       enable-access-analyzer:
@@ -66,6 +68,8 @@ jobs:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Init CI log directory
         if: ${{ inputs.enable-ci-logs }}
@@ -79,7 +83,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          fi
 
       - name: Lint (ruff)
         if: hashFiles('requirements-dev.txt') != '' && success()
@@ -101,7 +107,7 @@ jobs:
           fi
 
       - name: Unit tests
-        if: hashFiles('tests/') != '' && success()
+        if: hashFiles('tests/**') != '' && success()
         env:
           ENABLE_LOGS: ${{ inputs.enable-ci-logs }}
         run: |
@@ -218,13 +224,20 @@ jobs:
           fi
 
       - name: Comment diff on PR
-        if: env.AWS_ROLE_ARN != ''
+        if: env.AWS_ROLE_ARN != '' && github.event_name == 'pull_request'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         env:
           DIFF: ${{ steps.diff.outputs.diff }}
         with:
           script: |
-            const diff = process.env.DIFF;
+            // GitHub comment bodies are capped at 65536 chars — truncate
+            // large diffs instead of failing the comment API call.
+            const MAX_DIFF = 60000;
+            let diff = process.env.DIFF || '';
+            if (diff.length > MAX_DIFF) {
+              diff = diff.slice(0, MAX_DIFF)
+                + '\n… diff truncated — see the workflow run logs for the full output.';
+            }
             const body = `### CDK Diff\n\n\`\`\`\n${diff}\n\`\`\``;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -279,7 +292,7 @@ jobs:
               'actor': os.environ['META_ACTOR'],
               'event': os.environ['META_EVENT'],
               'job_status': os.environ['META_JOB_STATUS'],
-              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+              'timestamp': datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
           with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
               json.dump(meta, f, indent=2)

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Gitleaks
         uses: gitleaks/gitleaks-action@f586c14365d4643c6aa59d472ae6e984bf47bb34  # v2.3.8

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -94,6 +94,8 @@ jobs:
       # The OIDC credential step itself is gated behind enable-ci-logs.
       id-token: write
       contents: read
+    env:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +105,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0  # full history required by gitleaks
+          persist-credentials: false
 
       - name: Init CI log directory
         if: ${{ inputs.enable-ci-logs }}
@@ -220,15 +223,19 @@ jobs:
               --cov-fail-under="$COV_THRESHOLD"
           fi
 
+      - name: Log shipping skipped (no AWS_ROLE_ARN)
+        if: always() && inputs.enable-ci-logs && env.AWS_ROLE_ARN == ''
+        run: echo "::warning::AWS_ROLE_ARN secret not set — skipping CI log shipping"
+
       - name: Configure AWS credentials for logging
-        if: always() && inputs.enable-ci-logs
+        if: always() && inputs.enable-ci-logs && env.AWS_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: Generate log metadata
-        if: always() && inputs.enable-ci-logs
+        if: always() && inputs.enable-ci-logs && env.AWS_ROLE_ARN != ''
         env:
           META_REPOSITORY: ${{ github.repository }}
           META_WORKFLOW: ${{ github.workflow }}
@@ -252,14 +259,14 @@ jobs:
               'actor': os.environ['META_ACTOR'],
               'event': os.environ['META_EVENT'],
               'job_status': os.environ['META_JOB_STATUS'],
-              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+              'timestamp': datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
           with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
               json.dump(meta, f, indent=2)
           "
 
       - name: Ship CI logs
-        if: always() && inputs.enable-ci-logs
+        if: always() && inputs.enable-ci-logs && env.AWS_ROLE_ARN != ''
         uses: Specter099/.github/.github/actions/ship-logs@main
         with:
           log-dir: ${{ runner.temp }}/ci-logs

--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -51,26 +51,30 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve inputs
         id: vars
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          PREFIX: ${{ inputs.s3-prefix }}
+          SHA: ${{ github.sha }}
         run: |
-          REPO_NAME="${{ github.event.repository.name }}"
-          PREFIX="${{ inputs.s3-prefix }}"
           if [ -z "$PREFIX" ]; then
             PREFIX="$REPO_NAME"
           fi
           DATE=$(date -u +%Y-%m-%d)
-          SHA="${{ github.sha }}"
           FILENAME="${REPO_NAME}-${DATE}-${SHA:0:7}.zip"
           echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
           echo "s3-key=${PREFIX}/${FILENAME}" >> "$GITHUB_OUTPUT"
 
       - name: Create zip archive
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
         run: |
-          git archive --format=zip --output="${{ steps.vars.outputs.filename }}" HEAD
-          SIZE=$(du -sh "${{ steps.vars.outputs.filename }}" | cut -f1)
+          git archive --format=zip --output="$FILENAME" HEAD
+          SIZE=$(du -sh "$FILENAME" | cut -f1)
           echo "ARCHIVE_SIZE=$SIZE" >> "$GITHUB_ENV"
 
       - name: Configure AWS credentials
@@ -80,17 +84,28 @@ jobs:
           aws-region: ${{ inputs.aws-region }}
 
       - name: Upload to S3
+        env:
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ inputs.s3-bucket }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          aws s3 cp "${{ steps.vars.outputs.filename }}" \
-            "s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}"
+          aws s3 cp "$FILENAME" "s3://${S3_BUCKET}/${S3_KEY}"
 
       - name: Write job summary
+        env:
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          FILENAME: ${{ steps.vars.outputs.filename }}
+          S3_BUCKET: ${{ inputs.s3-bucket }}
+          S3_KEY: ${{ steps.vars.outputs.s3-key }}
         run: |
-          echo "## Repo Backup" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Repository | \`${{ github.repository }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Archive | \`${{ steps.vars.outputs.filename }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Size | $ARCHIVE_SIZE |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| S3 URI | \`s3://${{ inputs.s3-bucket }}/${{ steps.vars.outputs.s3-key }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Repo Backup"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Repository | \`${REPOSITORY}\` |"
+            echo "| Commit | \`${SHA}\` |"
+            echo "| Archive | \`${FILENAME}\` |"
+            echo "| Size | $ARCHIVE_SIZE |"
+            echo "| S3 URI | \`s3://${S3_BUCKET}/${S3_KEY}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -67,6 +67,8 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Init CI log directory
         if: ${{ inputs.enable-ci-logs }}
@@ -109,12 +111,12 @@ jobs:
           aws-region: ${{ inputs.aws-region }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       - name: CDK Deploy
         working-directory: ${{ inputs.infra-dir }}
@@ -202,7 +204,7 @@ jobs:
               'actor': os.environ['META_ACTOR'],
               'event': os.environ['META_EVENT'],
               'job_status': os.environ['META_JOB_STATUS'],
-              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+              'timestamp': datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
           with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
               json.dump(meta, f, indent=2)

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -52,6 +52,12 @@ on:
           ci-log-destination includes 'cloudwatch'.
         type: string
         default: ""
+    secrets:
+      AWS_ROLE_ARN:
+        description: >-
+          IAM role ARN for OIDC federation (required for synth/diff and
+          CI log shipping)
+        required: true
 
 jobs:
   review:
@@ -64,6 +70,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Init CI log directory
         if: ${{ inputs.enable-ci-logs }}
@@ -140,6 +148,7 @@ jobs:
           INFRA_DIR: ${{ inputs.infra-dir }}
         run: |
           set -o pipefail
+          pip install pip-audit
           if [ "$ENABLE_LOGS" = "true" ]; then
             pip-audit -r "$INFRA_DIR/requirements.txt" 2>&1 | tee "$RUNNER_TEMP/ci-logs/pip-audit.log"
           else
@@ -182,12 +191,20 @@ jobs:
           fi
 
       - name: Comment diff on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         env:
           DIFF: ${{ steps.diff.outputs.diff }}
         with:
           script: |
-            const diff = process.env.DIFF;
+            // GitHub comment bodies are capped at 65536 chars — truncate
+            // large diffs instead of failing the comment API call.
+            const MAX_DIFF = 60000;
+            let diff = process.env.DIFF || '';
+            if (diff.length > MAX_DIFF) {
+              diff = diff.slice(0, MAX_DIFF)
+                + '\n… diff truncated — see the workflow run logs for the full output.';
+            }
             const body = `### CDK Diff\n\n\`\`\`\n${diff}\n\`\`\``;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -238,7 +255,7 @@ jobs:
               'actor': os.environ['META_ACTOR'],
               'event': os.environ['META_EVENT'],
               'job_status': os.environ['META_JOB_STATUS'],
-              'timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+              'timestamp': datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
           }
           with open(os.path.join(os.environ['RUNNER_TEMP'], 'ci-logs', 'metadata.json'), 'w') as f:
               json.dump(meta, f, indent=2)

--- a/.github/workflows/validate-bucket-names.yml
+++ b/.github/workflows/validate-bucket-names.yml
@@ -31,12 +31,15 @@ jobs:
     steps:
       - name: Checkout caller repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Checkout .github repo (for shared scripts)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: Specter099/.github
           path: .shared-github
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,12 @@ python scripts/check_no_public_access.py --template-dir /path/to/cdk.out
     access-analyzer-check.yml # IAM Access Analyzer public access check
     validate-bucket-names.yml # S3 bucket naming convention enforcement
     gitleaks.yml              # Secret scan (reusable wrapper)
+    self-test.yml             # PR check for this repo (yamllint + pytest)
   actions/
     setup-cdk/action.yml      # Composite: Python 3.12 + Node 22 + CDK CLI
     access-analyzer/action.yml # Composite: scan CFN templates for public access
+    ship-logs/action.yml      # Composite: upload step logs to S3/CloudWatch
+  dependabot.yml              # Weekly bumps for SHA-pinned actions
   PULL_REQUEST_TEMPLATE.md    # Org-wide default PR template (applies to any repo without its own)
 scripts/
   check_no_public_access.py   # CLI for IAM Access Analyzer CheckNoPublicAccess API
@@ -64,6 +67,9 @@ All workflows use `workflow_call` triggers — caller repos reference them with 
 |---|---|---|
 | `AWS_ROLE_ARN` | Environment secret | IAM role ARN for OIDC federation (all AWS workflows) |
 | `BACKUP_S3_BUCKET` | Environment variable | S3 bucket for repo backups (`backup.yml`) |
+| `CDK_CLI_VERSION` | Repository variable | CDK CLI version fallback when the `cdk-version` input is unset |
+| `CI_LOGS_BUCKET` | Repository variable | S3 bucket fallback for CI log shipping (`ship-logs`) |
+| `CI_LOGS_LOG_GROUP` | Repository variable | CloudWatch log group fallback for CI log shipping (`ship-logs`) |
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Full review of the shared workflows and composite actions, fixing correctness bugs and applying security hardening across all 11 workflows.

**Correctness fixes**
- **`cdk-review`: unit tests were silently skipped in every caller.** `hashFiles('tests/')` is a directory path, which matches no files and always returns `''`, so the `Unit tests` step never ran. Changed to `hashFiles('tests/**')`.
- **`cdk-review`: dev-dependency install failures were swallowed.** `[ -f requirements-dev.txt ] && pip install ... || true` masked pip errors; replaced with an explicit `if`.
- **`python-ci`: callers without `AWS_ROLE_ARN` failed by default.** `enable-ci-logs` defaults to `true`, but the credentials/ship steps ran unconditionally and failed when the secret was absent. They are now gated on the secret being set (matching `cdk-review`), with a warning annotation when shipping is skipped.
- **`static-site-review`: `pip-audit` was never installed** before use (it only works if callers happen to list it in requirements-dev); now installed explicitly like in `python-ci`.
- **Diff PR comments**: only post on `pull_request` events (previously `context.issue.number` would throw on other events), and truncate diffs above GitHub's 65,536-char comment body limit instead of failing the API call.

**Security hardening**
- **Pin `docker/setup-qemu-action` (v3.7.0) and `docker/setup-buildx-action` (v3.12.0) to commit SHAs** in `static-site-deploy` — they were the only actions on mutable tags; SHAs verified against the upstream repos and covered by the existing Dependabot config.
- **`persist-credentials: false` on every checkout** — by default the repo token stays in `.git/config`, readable by any build/test/synth step that runs caller code. No workflow here pushes back to the repo, so nothing needs it.
- **Move `${{ }}` interpolations out of `run:` scripts into `env:`** in `cdk-deploy` (smoke-test-url), `repo-backup`, and `backup` — closes script-injection vectors from caller-controlled inputs and matches the pattern the other workflows already use.
- **`static-site-review`: declare `AWS_ROLE_ARN` in the `workflow_call` secrets block** — previously undeclared, so callers could only supply it via `secrets: inherit`; explicit passing now works and the interface is self-documenting.

**Cleanup**
- Replace deprecated `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)` in the metadata steps (silences the Python 3.12 DeprecationWarning).
- `cdk-review`: correct the `smoke-test-url` input description (it is unused in review; kept for interface consistency, as already documented in `static-site-review`).
- CLAUDE.md: add the `ship-logs` action, `self-test.yml`, `dependabot.yml`, and the `CDK_CLI_VERSION` / `CI_LOGS_BUCKET` / `CI_LOGS_LOG_GROUP` variables that were missing from the docs.

**Recommendations not implemented here** (future work):
- The ~30-line "Generate log metadata" step is duplicated in 5 workflows — it could move into the `ship-logs` composite action.
- Add `actionlint` to `self-test.yml`; it would have caught the `hashFiles` bug statically.
- Consider `concurrency` groups with `cancel-in-progress: true` inside the review workflows so callers don't each have to set them.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Infrastructure / CI change
- [x] Documentation

## Checklist

- [x] I have tested these changes locally (or explained why that isn't possible) — `yamllint` and the full pytest suite (48 tests) pass; workflow behavior changes can only be exercised by caller runs
- [x] I have updated documentation where relevant
- [x] CI checks (lint, tests, synth/diff, security scans) pass
- [x] No secrets, credentials, or account IDs are hardcoded

## Related issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkWm72QqLzpsjiNr6XcfBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkWm72QqLzpsjiNr6XcfBQ)_