### PR TITLE
Only attempt CI log shipping when AWS credentials actually configured

### DIFF
--- a/.github/workflows/cdk-review.yml
+++ b/.github/workflows/cdk-review.yml
@@ -149,6 +149,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
+        id: configure-aws-credentials
         if: env.AWS_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
@@ -299,7 +300,7 @@ jobs:
           "
 
       - name: Ship CI logs
-        if: always() && inputs.enable-ci-logs && env.AWS_ROLE_ARN != ''
+        if: always() && inputs.enable-ci-logs && steps.configure-aws-credentials.outcome == 'success'
         uses: Specter099/.github/.github/actions/ship-logs@main
         with:
           log-dir: ${{ runner.temp }}/ci-logs
@@ -307,3 +308,7 @@ jobs:
           s3-bucket: ${{ inputs.ci-log-s3-bucket != '' && inputs.ci-log-s3-bucket || vars.CI_LOGS_BUCKET }}
           cloudwatch-log-group: ${{ inputs.ci-log-cloudwatch-group != '' && inputs.ci-log-cloudwatch-group || vars.CI_LOGS_LOG_GROUP }}
           aws-region: ${{ inputs.aws-region }}
+
+      - name: Skip CI log shipping (no AWS credentials)
+        if: always() && inputs.enable-ci-logs && steps.configure-aws-credentials.outcome != 'success'
+        run: echo "::notice::Skipping CI log shipping — no working AWS credentials for this run (secret unset or OIDC assume-role failed)."


### PR DESCRIPTION
## Summary

Follow-up to #117. That PR fixed `ship-logs` failing when `CI_LOGS_BUCKET`/`CI_LOGS_LOG_GROUP` aren't configured, but `cdk-review.yml`'s "Ship CI logs" step still runs whenever the `AWS_ROLE_ARN` secret is merely *set* (`env.AWS_ROLE_ARN != ''`), regardless of whether "Configure AWS credentials" actually succeeded. Observed on `access-analyzer-pipeline#19`: `CI_LOGS_BUCKET` *is* configured there, so after the OIDC assume-role step failed, "Ship CI logs" still ran and crashed with `Unable to locate credentials` trying to `aws s3 cp` — a second, unrelated failure stacked on top of the real one.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Infrastructure / CI change
- [ ] Documentation

## Test plan

- [x] `yaml.safe_load` and `yamllint -c .yamllint.yml` pass on the modified file

## Scope note

This only changes the "Ship CI logs" step's condition (plus a new notice step for the skip case). CDK Synth, IAM Access Analyzer, CDK Nag, CDK Diff, and the PR-comment step are untouched — they still hard-fail the job on an OIDC assume-role failure exactly as before. Nothing here changes when those security-relevant checks run or how they fail.

## Related issues

Discovered while re-verifying #117 fixed CI on `Specter099/access-analyzer-pipeline#19` — the underlying OIDC trust-policy issue on that PR is a separate, AWS-side problem this doesn't address.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HzcxekoUSGUvhpv2sodRkk)_