### PR TITLE
fix(python-ci): grant pull-requests: read for gitleaks PR scan

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -94,6 +94,10 @@ jobs:
       # The OIDC credential step itself is gated behind enable-ci-logs.
       id-token: write
       contents: read
+      # pull-requests: read lets gitleaks-action list the PR's commits on
+      # pull_request events; without it the scan 403s ("Resource not
+      # accessible by integration").
+      pull-requests: read
     env:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
     strategy:


### PR DESCRIPTION
## Summary
- `gitleaks/gitleaks-action` lists a PR's commits via `GET /repos/{owner}/{repo}/pulls/{n}/commits`, which requires `pull-requests: read` on `GITHUB_TOKEN`.
- The `ci` job's `permissions` block only granted `id-token: write` and `contents: read`. Since a reusable workflow's own `permissions:` block is authoritative (callers can't widen it), every consumer running `python-ci` on `pull_request` events 403'd:
  ```
  RequestError [HttpError]: Resource not accessible by integration
  status: 403 ... 'x-accepted-github-permissions': 'pull_requests=read'
  url: .../pulls/<n>/commits
  ```
- Adds `pull-requests: read` to `jobs.ci.permissions` in `.github/workflows/python-ci.yml`. Permissions-widening only, no other files changed.

## Test plan
- [ ] Merge to `main`
- [ ] Confirm a caller repo's next PR run of `python-ci.yml@main` no longer 403s on the gitleaks step