### PR TITLE
Actions review report, plus a local CI/CD gate that enforces its findings

### DIFF
--- a/.github/workflow-invariants-baseline.yml
+++ b/.github/workflow-invariants-baseline.yml
@@ -1,0 +1,94 @@
+---
+# Accepted findings for scripts/check_workflow_invariants.py.
+#
+# This is a WORK LIST, not a suppression list. Every entry is a real finding
+# from the 2026-07-25 review (docs/reviews/2026-07-25-actions-security-
+# efficiency-review.md) that predates the checker. Baselining them keeps the
+# local gate green on a clean checkout so that *new* violations are the only
+# thing that fails — otherwise the gate is noise and people stop running it.
+#
+# Removing an entry is how you claim the fix: delete the line, run
+# `./scripts/local-ci.sh`, and it should stay green.
+#
+# To see everything including accepted findings:
+#   python scripts/check_workflow_invariants.py --strict --fail-on-warn
+#
+# Fingerprint format: <check-id>:<path>:<detail>  (no line number, so edits
+# above a finding don't silently un-baseline it)
+
+accepted:
+  # --- WF005: undeclared secrets force callers into `secrets: inherit` -------
+  # Review finding S4. Fix: add a workflow_call.secrets block to each; three
+  # other workflows already do it correctly and serve as the pattern.
+  - fingerprint: "WF005:.github/workflows/access-analyzer-check.yml:references secrets.AWS_ROLE_ARN but does not declare it"
+    review: S4
+  - fingerprint: "WF005:.github/workflows/cdk-deploy.yml:references secrets.AWS_ROLE_ARN but does not declare it"
+    review: S4
+  - fingerprint: "WF005:.github/workflows/repo-backup.yml:references secrets.AWS_ROLE_ARN but does not declare it"
+    review: S4
+  - fingerprint: "WF005:.github/workflows/static-site-deploy.yml:references secrets.AWS_ROLE_ARN but does not declare it"
+    review: S4
+
+  # --- WF012: README documents an input that does not exist -----------------
+  # Review finding "Documentation drift" #1. python-ci's input is
+  # `python-versions` and takes a JSON array; GitHub rejects unknown inputs,
+  # so this example fails outright for anyone who copies it.
+  - fingerprint: "WF012:README.md:python-ci.yml example passes 'python-version', which is not a declared input"
+    review: docs-1
+
+  # --- WF004: internal actions referenced at mutable @main ------------------
+  # Review finding S6 / TODO.md P0. A push to this repo's default branch
+  # propagates instantly to every caller, including deploys holding prod
+  # credentials. Fix: tag this repo and pin these by SHA.
+  - fingerprint: "WF004:.github/workflows/access-analyzer-check.yml:Specter099/.github/.github/actions/access-analyzer@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/cdk-deploy.yml:Specter099/.github/.github/actions/setup-cdk@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/cdk-deploy.yml:Specter099/.github/.github/actions/ship-logs@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/cdk-review.yml:Specter099/.github/.github/actions/setup-cdk@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/cdk-review.yml:Specter099/.github/.github/actions/access-analyzer@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/cdk-review.yml:Specter099/.github/.github/actions/ship-logs@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/python-ci.yml:Specter099/.github/.github/actions/ship-logs@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/static-site-deploy.yml:Specter099/.github/.github/actions/setup-cdk@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/static-site-deploy.yml:Specter099/.github/.github/actions/ship-logs@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/static-site-review.yml:Specter099/.github/.github/actions/setup-cdk@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/static-site-review.yml:Specter099/.github/.github/actions/ship-logs@main"
+    review: S6
+  - fingerprint: "WF004:.github/workflows/validate-bucket-names.yml:checkout of Specter099/.github with no ref (implicit default branch)"
+    review: S6
+
+  # --- WF007: fixed GITHUB_OUTPUT heredoc delimiter on cdk diff output ------
+  # Review finding S5. cdk diff text is PR-derived; a line reading exactly
+  # `EOF` terminates the block early and can forge later step outputs.
+  - fingerprint: "WF007:.github/workflows/cdk-review.yml:output 'diff' uses fixed heredoc delimiter 'EOF'"
+    review: S5
+  - fingerprint: "WF007:.github/workflows/static-site-review.yml:output 'diff' uses fixed heredoc delimiter 'EOF'"
+    review: S5
+
+  # --- WF008: no concurrency group on PR-check workflows --------------------
+  # Review finding E1. Likely the largest runner-minute saving available.
+  - fingerprint: "WF008:.github/workflows/cdk-review.yml:job 'review'"
+    review: E1
+  - fingerprint: "WF008:.github/workflows/python-ci.yml:job 'ci'"
+    review: E1
+  - fingerprint: "WF008:.github/workflows/self-test.yml:job 'test'"
+    review: E1
+  - fingerprint: "WF008:.github/workflows/static-site-review.yml:job 'review'"
+    review: E1
+
+  # --- WF011: vestigial input ----------------------------------------------
+  # Kept deliberately for caller interface parity with the deploy workflows;
+  # both declarations carry a comment saying so. Accepted indefinitely rather
+  # than pending a fix.
+  - fingerprint: "WF011:.github/workflows/cdk-review.yml:input 'smoke-test-url' is declared but never referenced"
+    review: intentional
+  - fingerprint: "WF011:.github/workflows/static-site-review.yml:input 'smoke-test-url' is declared but never referenced"
+    review: intentional

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Install dev dependencies
         run: pip install -r requirements-dev.txt
 
-      - name: Lint YAML (yamllint)
-        run: yamllint -c .yamllint.yml .github/
-
-      - name: Run tests (pytest)
-        run: pytest tests/ -v
+      # Single entrypoint shared with local development, so that a green
+      # `./scripts/local-ci.sh` on a laptop means a green check here. Stages:
+      # yamllint, ruff, pytest, workflow invariants, actionlint; zizmor runs
+      # advisory. Add or remove stages in the script, not here.
+      - name: CI gate (scripts/local-ci.sh)
+        run: ./scripts/local-ci.sh --format github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,26 @@ Shared GitHub Actions reusable workflows and composite actions for the Specter09
 
 ## Common Commands
 
+# The pre-commit gate — run this before every commit. Mirrors self-test.yml,
+# so green here means green in CI. ~3s.
+./scripts/local-ci.sh
+
+# ...auto-formatting first, and showing the baselined work list
+./scripts/local-ci.sh --fix
+./scripts/local-ci.sh --strict
+
+# Install it as a git pre-commit hook (bypass with git commit --no-verify)
+./scripts/local-ci.sh --install-hook
+
+# CD-side checks against a caller repo: synth, then bucket names + access analyzer
+./scripts/local-ci.sh --cdk-project ../bitwarden-cdk
+
 # Lint all YAML files
 yamllint -c .yamllint.yml .github/
+
+# Org workflow conventions (also runnable against a caller repo)
+python scripts/check_workflow_invariants.py --list-checks
+python scripts/check_workflow_invariants.py --path ../bitwarden-cdk --strict
 
 # Validate bucket naming script locally
 python scripts/validate_bucket_names.py --path /path/to/cdk/project
@@ -38,9 +56,14 @@ python scripts/check_no_public_access.py --template-dir /path/to/cdk.out
     ship-logs/action.yml      # Composite: upload step logs to S3/CloudWatch
   dependabot.yml              # Weekly bumps for SHA-pinned actions
   PULL_REQUEST_TEMPLATE.md    # Org-wide default PR template (applies to any repo without its own)
+  workflow-invariants-baseline.yml  # Accepted (pre-existing) invariant findings — a work list
 scripts/
+  local-ci.sh                 # The pre-commit gate. Same stages as self-test.yml
+  check_workflow_invariants.py # Org workflow conventions (WF001–WF014)
   check_no_public_access.py   # CLI for IAM Access Analyzer CheckNoPublicAccess API
   validate_bucket_names.py    # AST-based S3 bucket_name= convention checker
+docs/
+  reviews/                    # Point-in-time security/efficiency reviews
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,4 +97,6 @@ All workflows use `workflow_call` triggers — caller repos reference them with 
 ## Code Style
 
 - YAML: `.yamllint.yml` config — line-length disabled, document-start disabled, truthy allows `on`
-- Python scripts: no formatter config in repo — follow existing style (type hints, argparse CLI, boto3)
+- Python: `ruff.toml` — `ruff format` defaults, and `select = ["E4", "E7", "E9", "F"]` (ruff's stable default set). Beyond that, follow existing style: type hints, argparse CLI, boto3.
+- `ruff` is pinned exactly in `requirements-dev.txt`. It changes its default rule set between minor releases, so an unpinned linter means local and CI enforce different rules — that exact drift turned a green local run red in CI. Bump the pin deliberately and review `ruff.toml` alongside it.
+- Broadening the ruff selection (`I`, `UP`, `RUF`, `SIM` are all reasonable) means fixing the findings that surface, so do it as its own change.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ Missing optional tools (`actionlint`, `zizmor`, `act`, `cdk`) are **skipped with
 an install hint** rather than failing, so a fresh clone is usable straight away.
 `actionlint` is auto-installed via `go install` when Go is present.
 
+Python tools are invoked as `python3 -m ruff` / `python3 -m pytest` rather than
+via a bare command, and `ruff` is pinned exactly in `requirements-dev.txt`.
+Both are load-bearing: a `ruff` shadowed earlier on `PATH` was a different
+version with a different default rule set than the one `pip` installed, which is
+the "green locally, red in CI" divergence this gate exists to prevent.
+`ruff.toml` then declares the rule set explicitly so a version bump can't move
+the goalposts silently.
+
 ### Testing the CD path
 
 A deploy can't be genuinely rehearsed locally — it needs AWS and a real CDK app.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,64 @@ jobs:
 
 ---
 
+## Local development
+
+Run the gate before committing. It executes the same stages as
+`.github/workflows/self-test.yml`, so a green run locally means a green check on
+the PR — and it takes about three seconds.
+
+```bash
+pip install -r requirements-dev.txt
+./scripts/local-ci.sh
+```
+
+| Flag | What it does |
+|------|--------------|
+| *(none)* | yamllint, ruff, pytest, workflow invariants, actionlint; zizmor advisory |
+| `--fix` | `ruff format` first, then the gate |
+| `--strict` | Ignore the invariants baseline — shows the outstanding work list |
+| `--fast` | Skip the slower advisory stages |
+| `--cdk-project DIR` | Also run the CD-side checks against a caller repo (below) |
+| `--act` | Execute `self-test.yml` locally under [`act`](https://github.com/nektos/act) (needs Docker) |
+| `--install-hook` | Install as `.git/hooks/pre-commit` (bypass with `git commit --no-verify`) |
+
+Missing optional tools (`actionlint`, `zizmor`, `act`, `cdk`) are **skipped with
+an install hint** rather than failing, so a fresh clone is usable straight away.
+`actionlint` is auto-installed via `go install` when Go is present.
+
+### Testing the CD path
+
+A deploy can't be genuinely rehearsed locally — it needs AWS and a real CDK app.
+What `--cdk-project` does instead is run the checks `cdk-review` would run,
+against a real synthesized template tree:
+
+```bash
+./scripts/local-ci.sh --cdk-project ../bitwarden-cdk
+```
+
+That runs `cdk synth`, then validates bucket names against both the Python
+source and the synthesized templates, then runs the IAM Access Analyzer check —
+which needs real credentials and is skipped with a notice if `aws sts
+get-caller-identity` fails. It also runs the workflow invariants against the
+caller repo, which is where trigger-convention violations tend to live.
+
+### Workflow invariants
+
+`scripts/check_workflow_invariants.py` enforces the conventions in this document
+that no off-the-shelf linter knows about — undeclared `workflow_call` secrets,
+unpinned internal actions, `pull_request_target`, script injection into `run:`,
+checks leaking into deploy workflows, README examples passing inputs that don't
+exist. `--list-checks` prints all of them.
+
+Findings that predate the checker are accepted in
+`.github/workflow-invariants-baseline.yml`. That file is a **work list, not a
+suppression list**: each entry cites the review finding it corresponds to, and
+deleting an entry is how you claim the fix. New violations fail the gate even
+while old ones are tolerated, and a test asserts the baseline contains no stale
+entries.
+
+---
+
 ## Composite Actions
 
 ### `setup-cdk`

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ pip install -r requirements-dev.txt
 | *(none)* | yamllint, ruff, pytest, workflow invariants, actionlint; zizmor advisory |
 | `--fix` | `ruff format` first, then the gate |
 | `--strict` | Ignore the invariants baseline — shows the outstanding work list |
-| `--fast` | Skip the slower advisory stages |
+| `--fast` | Explicitly opt out of `zizmor` and `actionlint` (skipped, not missing) |
 | `--cdk-project DIR` | Also run the CD-side checks against a caller repo (below) |
 | `--act` | Execute `self-test.yml` locally under [`act`](https://github.com/nektos/act) (needs Docker) |
 | `--install-hook` | Install as `.git/hooks/pre-commit` (bypass with `git commit --no-verify`) |

--- a/README.md
+++ b/README.md
@@ -213,9 +213,22 @@ pip install -r requirements-dev.txt
 | `--act` | Execute `self-test.yml` locally under [`act`](https://github.com/nektos/act) (needs Docker) |
 | `--install-hook` | Install as `.git/hooks/pre-commit` (bypass with `git commit --no-verify`) |
 
-Missing optional tools (`actionlint`, `zizmor`, `act`, `cdk`) are **skipped with
-an install hint** rather than failing, so a fresh clone is usable straight away.
-`actionlint` is auto-installed via `go install` when Go is present.
+Stages come in three kinds, and the distinction is load-bearing:
+
+- **required** — `yamllint`, `ruff`, `pytest`, workflow invariants, `actionlint`.
+  These are what CI runs. If one *cannot* run because its tool is absent, the
+  verdict is **INCOMPLETE** (exit 1), never PASS. An earlier version skipped a
+  missing `yamllint` and still printed "Safe to commit", which reproduced the
+  very local/CI divergence the gate exists to prevent — "I didn't check" is not
+  "it's fine".
+- **advisory** — `zizmor`, `act`. Report findings, never block.
+- **optional** — `cdk`, `aws`. Only used by the CD stages; skipped when absent.
+
+`actionlint` is auto-installed via `go install` at a pinned version when Go is
+present; if one is already on `PATH` at a different version, the gate says so,
+since two versions report different findings. Use `--fast` to opt out of
+`zizmor` and `actionlint` explicitly — an explicit opt-out counts as skipped
+rather than missing, so PASS is still reachable.
 
 Python tools are invoked as `python3 -m ruff` / `python3 -m pytest` rather than
 via a bare command, and `ruff` is pinned exactly in `requirements-dev.txt`.
@@ -252,9 +265,18 @@ exist. `--list-checks` prints all of them.
 Findings that predate the checker are accepted in
 `.github/workflow-invariants-baseline.yml`. That file is a **work list, not a
 suppression list**: each entry cites the review finding it corresponds to, and
-deleting an entry is how you claim the fix. New violations fail the gate even
-while old ones are tolerated, and a test asserts the baseline contains no stale
-entries.
+deleting an entry is how you claim the fix. A test asserts the baseline contains
+no stale entries, so fixing something forces its entry out and a later
+regression has nothing left to hide behind.
+
+**New violations fail the gate at every severity, baselined ones don't.** The
+gate always passes `--fail-on-warn`, so a newly-introduced `warn` finding blocks
+just as an `error` does — the severities rank importance, they don't decide what
+blocks. This matters because WF004 (mutable internal `@main`) and WF007
+(forgeable `GITHUB_OUTPUT` delimiter) are `warn`, and those are two of the
+security findings the review pins down; leaving them advisory in the mode CI
+runs would have let a fresh violation of either through the required check.
+Running the checker directly without `--fail-on-warn` is the lenient mode.
 
 ---
 

--- a/docs/reviews/2026-07-25-actions-security-efficiency-review.md
+++ b/docs/reviews/2026-07-25-actions-security-efficiency-review.md
@@ -1,0 +1,424 @@
+# GitHub Actions Deep Review — Security & Efficiency
+
+**Date:** 2026-07-25
+**Scope:** `.github/workflows/*.yml` (11 workflows), `.github/actions/*/action.yml` (3 composite actions), `scripts/*.py` (2 helper scripts), `.github/dependabot.yml`
+**Baseline:** `yamllint -c .yamllint.yml .github/` clean; `pytest tests/` 48 passed.
+**Tooling:** `zizmor 1.28.0 --persona=auditor --offline` → 36 findings (12 high, 11 medium, 13 low). Findings below that zizmor corroborates are marked *(zizmor)*.
+
+This is a recommendations document. Nothing in the workflows was changed.
+
+---
+
+## Executive summary
+
+The estate is in decent shape on the basics that usually go wrong: third-party actions are SHA-pinned, `persist-credentials: false` is set on every checkout, every job has a `timeout-minutes`, caller-controlled shell inputs are passed through `env:` rather than interpolated into `run:`, and `github-script` reads the CDK diff from `process.env` instead of `${{ }}`. Several items already closed in `TODO.md` (script-injection guard on `CDK_STACKS`, the CDK Nag silent-failure fix, the `github-script` diff truncation) hold up under review.
+
+The problems that remain cluster into four themes:
+
+1. **The PR-review workflows hold real AWS credentials while executing PR-authored code.** This is the highest-severity issue in the repo and it is structural, not a typo (S1).
+2. **The most important gate can silently do nothing.** `cdk-review.yml` skips synth, diff and Access Analyzer with a `::warning::` when `AWS_ROLE_ARN` resolves empty — which is exactly what happens under the setup the README documents (S2).
+3. **CI log shipping is the largest unforced risk-and-cost surface.** `tee` writes files *before* GitHub's secret masking, and those files go to S3/CloudWatch by default on every run (S3, E7).
+4. **Wall-clock waste is concentrated in a few fixable places**: no concurrency cancellation, three CDK synths per review, a redundant `pip install`, and an npm cache key that guarantees the cache never updates (E1–E4).
+
+Highest-leverage single change: **add `zizmor` and `actionlint` to `self-test.yml`.** Most of the low/medium findings below are things a linter should be catching on every PR to this repo rather than in a periodic manual review.
+
+---
+
+## Security
+
+### S1 — Review workflows execute untrusted PR code with AWS credentials held *(High)*
+
+**Files:** `cdk-review.yml:151-225`, `static-site-review.yml:158-191`
+
+`cdk-review` assumes the OIDC role (`:151`) and then runs, in order, `cdk synth` (`:159`), the Access Analyzer action (`:171`), `CDK_NAG=true cdk synth` (`:190`), and `cdk diff` (`:210`). `cdk synth` executes `app.py` — arbitrary Python from the PR head. Before that, `Install dependencies` (`:83`) has already run `pip install -r requirements.txt` from the PR head, which executes arbitrary `setup.py`/build-backend code. `static-site-review` additionally runs `npm ci` and `npm run build` (`:86-126`), i.e. arbitrary `postinstall` scripts.
+
+Anyone who can open a PR — plus every transitive dependency in `requirements.txt` and `package-lock.json` — therefore gets code execution in a job that holds credentials for the role behind `AWS_ROLE_ARN`, for the default 1-hour session. If that is the same role the deploy workflows use (which `secrets: inherit` and a single `production` environment make the path of least resistance), a PR comment is a production credential.
+
+This is inherent to running `cdk diff` on a PR — the diff genuinely needs read access to the deployed stacks. The goal is to shrink the blast radius, not eliminate the pattern:
+
+- **Use a distinct review role.** Scope it to `cloudformation:GetTemplate`/`Describe*`/`GetTemplateSummary`, `accessanalyzer:CheckNoPublicAccess`, `sts:GetCallerIdentity`, and `s3:PutObject` on the CI-logs prefix only. Nothing that can mutate infrastructure. Pass it as a separate secret (`AWS_REVIEW_ROLE_ARN`) so `secrets: inherit` can't accidentally hand the deploy role to a PR job.
+- **Scope the OIDC trust policy by subject.** `repo:Specter099/<repo>:pull_request` for the review role, `repo:Specter099/<repo>:environment:production` for the deploy role. This is the control that actually prevents a review job from assuming the deploy role even if the ARN leaks.
+- **Add `role-duration-seconds: 900`** to both review workflows. A stolen 15-minute credential is materially less useful than a 60-minute one.
+- **Split the job (see E5).** Run `pip install` / `npm ci` / lint / tests / bandit in a job with *no* credentials, and do credentialed synth/diff in a second job. This does not fully isolate `cdk synth` (which still runs app code), but it removes dependency-install and test execution — the largest untrusted-code surface — from the credentialed job entirely, and it's a wall-clock win regardless.
+
+### S2 — `cdk-review` reports success while skipping every infrastructure check *(High)*
+
+**Files:** `cdk-review.yml:60-68, 151-269`; same shape in `python-ci.yml:230-233`
+
+The review job declares no `environment:`. `README.md` and `CLAUDE.md` both document `AWS_ROLE_ARN` as an **environment** secret on `production`. Environment secrets are only available to jobs that declare `environment:` — so under the documented configuration, `secrets.AWS_ROLE_ARN` in `cdk-review` resolves to the empty string.
+
+Every AWS-dependent step is gated on `if: env.AWS_ROLE_ARN != ''` (`:153`, `:160`, `:172`, `:191`, `:211`, `:228`). All of them skip. The job then emits `::warning::AWS_ROLE_ARN secret not set — skipping synth/diff` (`:267-269`) and **exits 0**. A required status check goes green having run zero of: synth, diff, CDK Nag, IAM Access Analyzer.
+
+`static-site-review` has the same missing `environment:` but declares the secret `required: true` and calls `configure-aws-credentials` unconditionally (`:158`), so it fails loudly instead. The two workflows disagree, and the silent one is the dangerous one.
+
+Recommendations, in order of preference:
+
+1. Add `environment: ${{ inputs.environment }}` (new input, default `production`) to the review jobs, matching `cdk-deploy`/`access-analyzer-check`. This makes the documented setup actually work.
+2. Add an `require-aws: true` input; when true, fail the job rather than warn if the ARN is empty.
+3. At minimum, make the fallback path fail: a review workflow that cannot review should not be able to satisfy a branch-protection rule.
+
+Note that `steps.configure-aws-credentials.outcome == 'success'` at `:303` is a good pattern — it correctly distinguishes "secret unset" from "assume-role failed". The problem is only that the overall job still passes.
+
+### S3 — `tee`'d logs bypass secret masking, then ship to S3/CloudWatch *(High)*
+
+**Files:** all five review/deploy workflows; `actions/ship-logs/action.yml`
+
+GitHub's secret redaction happens in the runner as it processes a step's output stream. `tee "$RUNNER_TEMP/ci-logs/*.log"` forks a copy of that stream **before** the runner sees it, so the on-disk file contains the raw, unmasked text. `ship-logs` then tars that directory and uploads it (`ship-logs:71-77`) and/or writes every line to CloudWatch (`:111-181`).
+
+Both `enable-ci-logs` and `ci-log-destination: both` default to on in every workflow. The highest-risk stream is `cdk deploy --verbose` (`cdk-deploy.yml:110`), which is verbose by design and routinely prints account IDs, ARNs, resolved SSM/Secrets Manager references, and CloudFormation parameter values. Anything GitHub would have starred out in the UI is stored in plaintext in S3 and CloudWatch.
+
+Recommendations:
+
+- Flip `enable-ci-logs` to `false` by default. Opt-in, not opt-out.
+- Default `ci-log-destination` to `s3` (matching the composite's own default) rather than `both`.
+- Drop `--verbose` from `cdk deploy`, or keep it only in the terminal stream and not in the `tee`'d file.
+- Require SSE-KMS on the logs bucket, a bucket policy denying `s3:GetObject` outside a named role, `BlockPublicAcls`/`IgnorePublicAcls`, and a short lifecycle expiry (the CloudWatch path already sets 90-day retention at `ship-logs:100-103`; S3 has no equivalent).
+- Consider a redaction pass over `$RUNNER_TEMP/ci-logs` before the ship step, even if only for high-entropy strings and `AWS_SECRET_ACCESS_KEY`-shaped values.
+
+### S4 — Five workflows force callers into `secrets: inherit` *(High)*
+
+**Files:** `access-analyzer-check.yml:54`, `cdk-deploy.yml:93`, `repo-backup.yml:83`, `static-site-deploy.yml:110`, `backup.yml:45` (the last is not `workflow_call`, so it's fine)
+
+`access-analyzer-check.yml`, `cdk-deploy.yml`, `repo-backup.yml` and `static-site-deploy.yml` all reference `secrets.AWS_ROLE_ARN` without declaring a `workflow_call.secrets:` block. An undeclared secret is only populated via `secrets: inherit`, which passes **every** secret the caller repository and its environment hold into the reusable workflow. `README.md` duly instructs `secrets: inherit` in all four usage examples.
+
+`cdk-review.yml`, `static-site-review.yml` and `python-ci.yml` already declare theirs correctly — use them as the pattern:
+
+```yaml
+    secrets:
+      AWS_ROLE_ARN:
+        description: IAM role ARN for OIDC federation
+        required: true
+```
+
+Then change the README examples to `secrets: { AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }} }`. This is a cheap fix that meaningfully narrows what a compromised or buggy shared workflow can reach.
+
+### S5 — `GITHUB_OUTPUT` heredoc uses a fixed `EOF` delimiter on attacker-influenced content *(Medium)*
+
+**Files:** `cdk-review.yml:216-222`, `static-site-review.yml:182-188`
+
+```bash
+diff_output=$(cdk diff 2>&1) || true
+{ echo "diff<<EOF"; echo "$diff_output"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+```
+
+`cdk diff` output is derived from PR-authored CDK code — stack names, resource logical IDs, descriptions, tag values. A line consisting of exactly `EOF` terminates the heredoc early, and everything after it is parsed as further `GITHUB_OUTPUT` assignments. That lets a PR set arbitrary step outputs for any later step that consumes them.
+
+Fix: use an unguessable delimiter per invocation.
+
+```bash
+delim="EOF_$(openssl rand -hex 16)"
+{ echo "diff<<$delim"; echo "$diff_output"; echo "$delim"; } >> "$GITHUB_OUTPUT"
+```
+
+The PR-comment step is already safe (it reads `process.env.DIFF`, not `${{ }}`) — this is specifically about the output-file write.
+
+### S6 — Internal actions referenced at mutable `@main` *(Medium)* *(zizmor: 12 × `unpinned-uses`)*
+
+**Files:** `cdk-review.yml:79,173,304`; `cdk-deploy.yml:73,197`; `static-site-review.yml:81,266`; `static-site-deploy.yml:78,215`; `python-ci.yml:274`; `access-analyzer-check.yml:63`; plus `validate-bucket-names.yml:37-42` (second checkout at implicit `main`)
+
+Third-party actions are correctly SHA-pinned. Every *internal* reference is not. A single push to `main` in this repository propagates immediately to every caller — including `cdk-deploy` jobs that hold production credentials. That means the effective security boundary for prod deploys across the whole org is write access to this repo's default branch, with no review-and-roll-forward step in between.
+
+This is `TODO.md` P0 ("Especially `Specter099/.github/.github/actions/{setup-cdk,access-analyzer,ship-logs}@main`") and P1 (`validate-bucket-names.yml` ref pin), still open.
+
+Recommendation: cut release tags (`v1`, `v1.2.0`) for this repo, pin internal `uses:` to the tag's SHA with a `# v1.2.0` comment, and add this repo's own path to `dependabot.yml` so bumps are auto-PR'd. Note `validate-bucket-names.yml:37-42` needs an explicit `ref:` on the checkout, not just a `uses:` pin.
+
+### S7 — `pull-requests: write` review jobs are one caller mistake from a serious escalation *(Medium)*
+
+**Files:** `cdk-review.yml:63-66`, `static-site-review.yml:67-70`, `validate-bucket-names.yml:27-29`
+
+Reusable workflows inherit the caller's trigger. Today callers use `pull_request` (per the documented convention), where fork PRs get a read-only token — so the write permission is unusable from a fork and the design holds. But the workflows themselves place no constraint on the trigger. A caller that switches to `pull_request_target` to "make comments work on forks" would get: checkout of fork-controlled code, a write-scoped `GITHUB_TOKEN`, **and** AWS credentials, in one job.
+
+Recommendations:
+
+- Add a guard step at the top of each review workflow: fail if `github.event_name == 'pull_request_target'`.
+- Document the constraint in `CLAUDE.md` next to the existing trigger convention, which currently covers `pull_request` vs `push` but says nothing about `pull_request_target`.
+- Consider dropping `pull-requests: write` from `validate-bucket-names.yml` — its comment step (`:60-89`) posts a static template containing no actual violation data, so the log output already tells the developer everything the comment does.
+
+### S8 — Unpinned package installs at runtime *(Medium)* *(zizmor: `adhoc-packages`)*
+
+**Files:** `cdk-review.yml:183`; `static-site-review.yml:151`; `python-ci.yml:176,189,217`; `actions/access-analyzer/action.yml:29`; `actions/setup-cdk/action.yml:49`
+
+`pip install bandit`, `pip install pip-audit`, `pip install pytest-cov`, `pip install --quiet --upgrade boto3 cfn-flip`, `npm install -g "aws-cdk@$CDK_VERSION"` — all resolve to whatever the registry serves at that moment, with no version constraint and no hash pinning. Any of these is a supply-chain foothold into a job that holds AWS credentials (see S1), and it also means CI results aren't reproducible: a bad `bandit` release breaks every caller's PR check simultaneously.
+
+Recommendation: move these into a pinned, hash-locked requirements file shipped with this repo (`.github/requirements-ci.txt` with `--require-hashes`), installed once. `aws-cdk` is at least version-pinned via the `cdk-version` input; the hardcoded `2.1106.1` fallback in `setup-cdk:27` is fine but should be kept in step with what Dependabot sees.
+
+### S9 — `fail-on-public-access: false` is not actually warn-only *(Low)*
+
+**File:** `actions/access-analyzer/action.yml:56-68`, `scripts/check_no_public_access.py:234-319`
+
+The composite maps `fail-on-public-access: false` to `--no-fail-on-public-access`, which only suppresses the exit-1 path for detected violations (`check_no_public_access.py:307-309`). Two other failure paths ignore the flag entirely:
+
+- missing `--template-dir` → `return 1` (`:236-239`)
+- any unparseable template or Access Analyzer API error → `return 2` (`:311-316`)
+
+The composite then does `exit "$rc"` (`:68`), so a "warn-only" configuration still hard-fails on an incomplete scan. That's defensible as a security default — an incomplete scan *shouldn't* silently pass — but it contradicts the input's documented meaning ("set 'false' for warn-only"). Either rename the input to `fail-on-violation` and document the exit-2 behaviour, or add a separate `fail-on-incomplete-scan` input.
+
+Related, same file: the `Notify on public access detected` step (`:70-73`) is gated on `if: failure()`, which in a composite reflects job-level failure. It therefore prints `::error::IAM Access Analyzer detected resources that grant public access` when the *`pip install`* failed, or when `cfn-flip` failed, or on an exit-2 incomplete scan — none of which are public-access findings. Gate it on the actual check step's outcome instead.
+
+### S10 — Access Analyzer coverage gaps *(Low)*
+
+**File:** `scripts/check_no_public_access.py:95-108, 33-91`
+
+Three separate gaps worth knowing about, all reasonable trade-offs but none currently documented for callers:
+
+1. `POLICY_MAP` covers 6 resource types. Access Analyzer `CheckNoPublicAccess` also supports (among others) `AWS::Lambda::Function` permissions, `AWS::EFS::FileSystem`, `AWS::Backup::BackupVault`, `AWS::ApiGateway::RestApi`, `AWS::OpenSearchService::Domain`, and `AWS::IAM::ManagedPolicy`. A publicly-invokable Lambda or a public API Gateway resource policy passes this check today.
+2. Only *explicit* policy resources are examined. An `AWS::S3::Bucket` with a permissive ACL or without `PublicAccessBlockConfiguration`, and no separate `AWS::S3::BucketPolicy` resource, is never checked. Worth pairing with a Checkov/cfn-nag rule rather than extending this script.
+3. `resolve_intrinsics` (`:33-91`) handles `Ref`, `Fn::Join`, `Fn::Sub`, `Fn::GetAtt`. `Fn::If`, `Fn::Select`, `Fn::ImportValue` and `Fn::FindInMap` fall through as dicts → invalid policy document → API error → exit 2 (a hard fail, per S9). And a `Principal` of `{"Ref": "SomeParameter"}` becomes a placeholder ARN, so a template whose parameter *defaults* to `*` is a false negative. The docstring acknowledges the substitution; it should also state the false-negative consequence.
+
+### S11 — `check_no_public_access.py` crashes instead of exiting 2 without credentials *(Low)*
+
+**File:** `scripts/check_no_public_access.py:251-254`
+
+`except ClientError` doesn't cover `NoCredentialsError` (a `BotoCoreError`). Verified locally with credentials stripped: the script raises an unhandled `botocore.exceptions.NoCredentialsError` traceback rather than the documented exit code. Same exposure on the `check_no_public_access` call at `:160`, where a `NoCredentialsError` or `EndpointConnectionError` escapes the `except ClientError` at `:172`. Widen to `except (ClientError, BotoCoreError)` and return 2.
+
+### S12 — No `role-session-name` anywhere *(Low)*
+
+**Files:** all 6 `configure-aws-credentials` call sites
+
+Every assume-role uses the action's default session name, so CloudTrail cannot attribute an API call to a repository, workflow, or run. Add `role-session-name: gha-${{ github.event.repository.name }}-${{ github.run_id }}` (64-char limit, so prefer repo name over full `github.repository`). This costs nothing and is the difference between a five-minute and a five-hour incident investigation.
+
+### S13 — `gitleaks.yml` has no way to supply a licence *(Low)*
+
+**File:** `gitleaks.yml:3-5, 20-23`
+
+`gitleaks/gitleaks-action@v3` requires `GITLEAKS_LICENSE` for organization-owned repositories above the free tier. The workflow declares no `workflow_call.secrets:` block at all, so a caller cannot pass one without switching to `secrets: inherit`. Add an optional `GITLEAKS_LICENSE` secret now; the fallback documented in `TODO.md` P2 (`docker://zricethezav/gitleaks` — pin it by digest, not `:latest`) remains the escape hatch. `python-ci.yml:165-168` has the same gap.
+
+### S14 — `backup.yml` hygiene *(Low)*
+
+**File:** `backup.yml:4-6, 13`
+
+- The scheduled job has no `if: github.repository == 'Specter099/.github'` guard, so any fork that keeps Actions enabled runs the weekly backup and fails against the upstream role.
+- `environment: production` on a backup job means backups are subject to production approval and branch-protection rules. `TODO.md` P1 already proposes `environment: backup`; that's the right call.
+- No `concurrency` group *(zizmor)*, so a `workflow_dispatch` during the scheduled window races the scheduled run for the same S3 key.
+
+---
+
+## Efficiency
+
+### E1 — No concurrency cancellation on any review workflow *(High)* *(zizmor: `concurrency-limits`)*
+
+**Files:** `cdk-review.yml`, `static-site-review.yml`, `python-ci.yml`, `validate-bucket-names.yml`, `access-analyzer-check.yml`, `self-test.yml`, `backup.yml`, `repo-backup.yml`
+
+Only the two deploy workflows set `concurrency` (correctly, with `cancel-in-progress: false`). Every review workflow lacks it, so three pushes to a PR in five minutes run three complete pipelines to completion — including three sets of `cdk synth`, three Access Analyzer sweeps, and three log shipments.
+
+`python-ci.yml:6-9` documents this as the caller's responsibility. That's the wrong default: it means every caller repo has to remember, and the ones that forget pay silently. Set it job-level inside the reusable workflow:
+
+```yaml
+    concurrency:
+      group: cdk-review-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+```
+
+For `python-ci`, the group **must** include `${{ matrix.python-version }}` or the matrix legs cancel each other.
+
+This is likely the single largest runner-minute saving available, and it's four lines per file.
+
+### E2 — `cdk-review` synthesizes the CDK app three times *(High)*
+
+**File:** `cdk-review.yml:159-225`
+
+1. `CDK Synth` (`:166`) — produces `cdk.out`
+2. `CDK Nag` (`:199`) — `CDK_NAG=true cdk synth`, a second full synth
+3. `CDK Diff` (`:216`) — `cdk diff` re-synthesizes internally, a third
+
+Synth is typically the slowest step in a CDK PR check (tens of seconds to minutes on a real app). Two of the three are avoidable:
+
+- `cdk diff --app cdk.out` reuses the assembly from step 1 instead of re-synthesizing. This also makes the diff consistent with the templates Access Analyzer actually scanned — today they are two independent synths that could in principle differ.
+- The Nag synth genuinely needs a different environment variable, so it can't share the first assembly. But it's independent of everything else in the job, so it belongs in a **parallel job** (see E5) rather than serially in the critical path. If parallelising isn't wanted, running Nag unconditionally in the first synth and filtering the captured output achieves the same in one pass.
+
+### E3 — Redundant `pip install -r requirements.txt` *(High)*
+
+**File:** `cdk-review.yml:83-88`
+
+`setup-cdk` (`:51-55`) already installs `requirements.txt` — that's its default `requirements-path`. The immediately following `Install dependencies` step installs it again. `TODO.md` P1 estimates ~15–30s per run; on a CDK project with `aws-cdk-lib` and boto3 it is often more.
+
+Keep the `requirements-dev.txt` half of that step (`:86-88`) — `setup-cdk` doesn't install it — and drop the `requirements.txt` line.
+
+### E4 — npm cache key guarantees the cache never updates *(High)*
+
+**File:** `actions/setup-cdk/action.yml:39-43`
+
+```yaml
+    - name: Cache npm
+      uses: actions/cache@...
+      with:
+        path: ~/.npm
+        key: npm-${{ runner.os }}-cdk-${{ steps.cdk-ver.outputs.version }}
+```
+
+The key contains no content hash, so it is constant for a given CDK version. `actions/cache` skips its post-run save on an exact key hit — so the cache is populated on the first run for a CDK version and then **frozen forever**. Two consequences:
+
+- For `static-site-review`/`static-site-deploy`, the caller's frontend dependencies are cached only as they existed on that first run. Every `package-lock.json` change after that re-downloads from the registry on every run, permanently. This is `TODO.md` P2, and it's underrated there — it's a per-run cost on the two heaviest workflows.
+- The cache also can't be invalidated when it goes stale or bad, short of bumping the CDK version.
+
+Recommendation — do both:
+
+```yaml
+        key: npm-${{ runner.os }}-cdk-${{ steps.cdk-ver.outputs.version }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          npm-${{ runner.os }}-cdk-${{ steps.cdk-ver.outputs.version }}-
+```
+
+and pass `cache: npm` + `cache-dependency-path` to the `actions/setup-node` call at `:35-37`, which handles this correctly out of the box. Note `setup-python`'s `cache: pip` (`:33`) has the same shape of issue less severely — it defaults to hashing `**/requirements.txt`, which works, but an explicit `cache-dependency-path` tied to `inputs.requirements-path` would be more predictable for the monorepo callers.
+
+### E5 — Everything runs in one serial job *(Medium)*
+
+**File:** `cdk-review.yml` (all 18 steps in one job); same in `static-site-review.yml`
+
+Lint, unit tests, pip-audit and bandit have no dependency on AWS credentials or on each other, yet they run serially ahead of (and in bandit's case, `:178`, *after*) the credentialed steps. `TODO.md` P2 proposes reordering for faster failure; splitting into parallel jobs is strictly better and solves S1's isolation problem at the same time:
+
+- **job `static-checks`** (no `id-token`, no credentials): checkout → setup → install → ruff → bandit → pytest → pip-audit
+- **job `infra`** (`id-token: write`): checkout → setup → configure-aws → synth → access-analyzer → diff → comment
+- **job `nag`** (`id-token: write`): checkout → setup → configure-aws → nag synth
+
+Wall clock becomes `max(...)` instead of `sum(...)`. The cost is repeated checkout+setup per job (~20–30s each, largely cache-served), which the parallelism more than repays on any non-trivial app. Log shipping then needs a small `needs: [...]` collector job with `if: always()`.
+
+Also at `:91` and `:110`: `if: hashFiles('requirements-dev.txt') != '' && success()` — the `&& success()` is redundant, that's the default step condition.
+
+### E6 — QEMU and Buildx set up unconditionally *(Medium)*
+
+**File:** `static-site-deploy.yml:113-119`
+
+`docker/setup-qemu-action` with `platforms: arm64` plus `setup-buildx-action` costs roughly 30–60s per deploy. They're only needed when the CDK app bundles Lambda functions (or containers) for arm64 via Docker. A pure static-site deploy — S3 + CloudFront, which is what the workflow's name promises — needs neither. Gate both behind an `enable-docker-bundling` input, default `false`.
+
+### E7 — CloudWatch shipping is per-line, and `both` is the default *(Medium)*
+
+**File:** `actions/ship-logs/action.yml:151-181`; `ci-log-destination` defaults in all five workflows
+
+Every line of every log file becomes an individual CloudWatch log event (`:161-169`), each carrying 26 bytes of accounting overhead on top of the message. For `cdk deploy --verbose` output this is a lot of events and a lot of ingest ($0.50/GB) — and because `ci-log-destination` defaults to `both` in all five workflows (overriding the composite's own `s3` default at `:13`), every run pays for S3 storage *and* CloudWatch ingest *and* 90 days of CloudWatch storage for the same bytes.
+
+Recommendations:
+- Default `ci-log-destination` to `s3`. S3 is the cheap, durable copy; CloudWatch should be opt-in for the runs someone actually wants to query.
+- If CloudWatch stays, batch lines into fewer, larger events rather than one per line. The existing batching (`:165`) batches the *API calls*, not the events.
+- Delete the dead `sequence_token` plumbing (`:124-147`) — `put-log-events` has ignored `--sequence-token` since August 2023, and removing it cuts the Python block substantially. This is `TODO.md` P1.
+- Failures are swallowed: `create-log-group`/`put-retention-policy`/`create-log-stream` are all `2>/dev/null || true` (`:97-108`), and `put_events` only prints a warning on failure (`:149`). A permissions misconfiguration produces a green "logs shipped" step and zero logs. At minimum, count failed batches and fail the step if any failed.
+
+### E8 — `fetch-depth: 0` in the backup workflows is pure waste *(Medium)*
+
+**Files:** `backup.yml:18-21`, `repo-backup.yml:51-54`
+
+Both fetch the complete history, then `git archive --format=zip HEAD` (`backup.yml:38`, `repo-backup.yml:76`) writes a snapshot of the working tree at HEAD. The history is fetched and immediately discarded.
+
+Two ways to resolve, depending on intent:
+
+- If a snapshot is what's wanted: drop `fetch-depth: 0`. On a large repo this is the majority of the job's runtime.
+- If a *backup* is what's wanted: the current artifact contains no history, no branches, no tags — restoring from it loses everything except the tip of the default branch. `git clone --mirror` + `git bundle create backup.bundle --all` produces a genuinely restorable backup and justifies the full fetch. Worth an explicit decision, since the workflow is named "Backup".
+
+Minor, same files: `du -sh "$FILENAME"` (`:39` / `:77`) reports disk usage (block-rounded), not archive size — `stat -c %s` or `du -b` is what the summary means.
+
+### E9 — Full second checkout to fetch two scripts *(Medium)*
+
+**File:** `validate-bucket-names.yml:37-42`
+
+The second `actions/checkout` clones all of `Specter099/.github` to use `scripts/validate_bucket_names.py`. Add `sparse-checkout: scripts/` and `sparse-checkout-cone-mode: false`, plus the `ref:` pin from S6. Small, but this workflow is meant to be a fast PR gate and the checkout is a meaningful share of its runtime.
+
+### E10 — Frontend built twice across review and deploy *(Medium)*
+
+**Files:** `static-site-review.yml:116-126`, `static-site-deploy.yml:95-105`
+
+`TODO.md` P3 already frames the decision (CI uploads `dist/` vs. CD rebuilds). Worth resolving rather than leaving open: the current state pays for two builds *and* leaves a drift window where the artifact CI validated is not the artifact CD ships. Given the deploy workflow's `concurrency` already serialises deploys, Option A (upload in review, download in deploy) is the stronger choice — it makes the deployed bundle byte-identical to the reviewed one, which is the whole point of the review gate.
+
+### E11 — `ENABLE_LOGS` boilerplate repeated ~30 times *(Low)*
+
+**Files:** all five review/deploy workflows
+
+Every logged step carries the same `if [ "$ENABLE_LOGS" = "true" ]; then <cmd> 2>&1 | tee <file>; else <cmd>; fi` block, with the command duplicated in both branches — a maintenance hazard, since the two copies can drift (and the `set -o pipefail` placement differs subtly between files).
+
+`TODO.md` P2 proposes a `run-with-optional-log` composite action. A simpler option: always `tee` into `$RUNNER_TEMP/ci-logs` (creating the directory unconditionally) and let the ship step be the only thing gated on `enable-ci-logs`. Writing a file to the runner's own temp costs nothing, and the branch disappears entirely.
+
+### E12 — Matrix jobs overwrite each other's shipped logs *(Low)*
+
+**Files:** `python-ci.yml:103-106, 272-280`; `actions/ship-logs/action.yml:50-56`
+
+The S3 key is `${S3_PREFIX}/${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}` and the CloudWatch stream is `${REPO}/${SAFE_WORKFLOW}/${RUN_ID}-${ATTEMPT}` — neither includes a job or matrix discriminator. With `python-versions: '["3.11","3.12"]'`, both legs upload to the identical `logs.tar.gz` key (last writer wins, silently) and interleave into a single CloudWatch stream. Add an optional `log-name-suffix` input to `ship-logs` and pass `${{ matrix.python-version }}`.
+
+### E13 — Assorted correctness nits *(Low)*
+
+- **PR comment duplicates on busy PRs.** `cdk-review.yml:243-247` / `static-site-review.yml:209-213` call `issues.listComments` with no pagination. The REST default is `per_page=30`, so once a PR has more than 30 comments the existing CDK-diff comment isn't found and a new one is created on every run. Use `github.paginate(github.rest.issues.listComments, {...})`, or at minimum `per_page: 100` with `sort: 'created', direction: 'desc'`.
+- **Unawaited API call.** `validate-bucket-names.yml:84-89` calls `github.rest.issues.createComment({...})` without `await`. `github-script` resolves the script's return value; a floating promise can be dropped when the action exits. Add `await`.
+- **`cdk diff` failures are indistinguishable from an empty diff.** `cdk-review.yml:216` / `static-site-review.yml:182`: `diff_output=$(cdk diff 2>&1) || true` discards the exit code, so a credentials error or a stack-lookup failure posts its error text as "the diff" and the step passes. Capture `rc` and emit at least a `::warning::` on non-zero.
+- **`pip install --upgrade pip` as a dedicated step** (`python-ci.yml:124-125`) costs a step's overhead for little benefit on a `setup-python` runner; fold it into the install step.
+- **`pip-audit` invoked inconsistently.** `cdk-review.yml:141` audits `-r requirements.txt`; `python-ci.yml:178` audits the whole installed environment. The latter is the more useful check (it sees transitive pins); pick one.
+- **Bandit exclude paths differ** between `cdk-review.yml:185` (`./.venv,./cdk.out,./lambda_layer`) and `python-ci.yml:191` (`.venv,cdk.out`). Bandit's `--exclude` matching is path-prefix sensitive; the leading `./` forms are the reliable ones.
+
+### E14 — Dependabot configuration *(Low)* *(zizmor: `dependabot-cooldown`)*
+
+**File:** `.github/dependabot.yml`
+
+- No `cooldown`. A compromised action release gets an auto-PR within a day, and the whole point of SHA pinning is to buy time for a bad release to be caught. Add `cooldown: { default-days: 7 }`.
+- All actions are grouped into a single PR (`:12-15`). One bump that breaks CI blocks every other bump behind it. Consider splitting security updates from version updates, or at least separating the AWS actions from the rest.
+- The `directories` list doesn't include this repo's own reusable-workflow references once S6's internal pinning lands — add whatever paths the pinned internal `uses:` end up in.
+
+### E15 — `validate_bucket_names.py` accuracy *(Low)*
+
+**File:** `scripts/validate_bucket_names.py:51`
+
+`BUCKET_NAME_RE = r"^[a-z0-9][a-z0-9-]+-\d{12}-[a-z]{2}-[a-z]+-\d-an$"` — verified locally:
+
+| Name | Result | Should be |
+|---|---|---|
+| `logs-123456789012-us-east-1-an` | pass | pass |
+| `logs-123456789012-ap-southeast-2-an` | pass | pass |
+| `logs-123456789012-cn-north-1-an` | pass | pass |
+| `logs-123456789012-us-gov-west-1-an` | **fail** | pass |
+| 106-char name, otherwise valid | **pass** | fail (S3 limit is 63) |
+
+The region group assumes exactly three segments, so four-segment regions (`us-gov-west-1`, `us-gov-east-1`) are reported as violations. And there's no length check, so a name CloudFormation will reject at deploy time passes the gate that exists to catch exactly that. Suggested: `^(?=.{3,63}$)[a-z0-9][a-z0-9-]+-\d{12}-[a-z]{2}(-[a-z]+)+-\d-an$`.
+
+Separately, `scan_directory` (`:130-136`) walks every `.py` under the scan root, excluding only `cdk.out`, `.venv`, `venv`, `node_modules`, `__pycache__`. Vendored dependencies, `build/`, `dist/`, and `site-packages` under a differently-named virtualenv all get scanned, producing violations for code the caller doesn't own. Add an `--exclude` argument.
+
+---
+
+## Documentation drift
+
+These aren't security or performance issues, but two of them will actively break a caller who follows the README.
+
+1. **`README.md` documents a `python-version` input for `python-ci`; the actual input is `python-versions`** and takes a JSON array (`python-ci.yml:14-19`). GitHub rejects unexpected inputs to a reusable workflow, so the README's `python-ci` example fails outright.
+2. **`CLAUDE.md` claims `cdk-review` runs Checkov.** It does not — there is no Checkov step. Either add `checkov -d .` (a good fit for the S10 gaps) or drop the claim. `TODO.md` P2.
+3. **The README documents 3 inputs per workflow; the workflows have 8–12.** Missing entirely: every `enable-ci-logs` / `ci-log-*` input, `stacks` and `environment` (`cdk-deploy`), `enable-access-analyzer` (`cdk-review`), and `coverage` / `coverage-threshold` / `bandit` / `pip-audit` / `install-command` / `tests-dir` (`python-ci`). `access-analyzer-check`, `validate-bucket-names` and `gitleaks` aren't documented at all.
+4. **The README's "Required secret" note** says all workflows assume `AWS_ROLE_ARN`; `cdk-review` declares it optional and `python-ci` needs it only for log shipping. Worth stating which workflows hard-require it — this is the documentation half of S2.
+5. **`cdk-review.yml` still accepts an unused `smoke-test-url`** (`:18-23`). It carries a comment explaining why, which satisfies `TODO.md` P1; leaving it is fine.
+6. **YAML header style is inconsistent** — `cdk-review.yml` and `python-ci.yml` open with `---` + `"on":`, the other nine don't. `TODO.md` P2. Cosmetic, but pick one and let yamllint enforce it.
+
+---
+
+## Suggested sequencing
+
+**First — make the gates real and stop the credential exposure**
+1. S2 — `environment:` on the review jobs, and fail rather than warn when the ARN is missing. Without this, some of the checks below are protecting nothing.
+2. S1 — separate least-privilege review role, subject-scoped OIDC trust policy, `role-duration-seconds: 900`.
+3. S3 — `enable-ci-logs` default `false`, `ci-log-destination` default `s3`, drop `--verbose` from the `tee`'d deploy stream.
+4. S4 — declare `workflow_call.secrets:` in the four workflows missing it; update README examples off `secrets: inherit`.
+
+**Second — cheap, high-return**
+5. E1 — job-level `concurrency` + `cancel-in-progress` in every review workflow (matrix-aware for `python-ci`).
+6. E3 — delete the duplicate `pip install`.
+7. E2 — `cdk diff --app cdk.out`.
+8. E4 — fix the npm cache key; use `setup-node`'s built-in cache.
+9. S5 — random `GITHUB_OUTPUT` heredoc delimiter.
+10. **Add `zizmor --persona=auditor` and `actionlint` to `self-test.yml`.** This is what keeps S6, E1, E14 and most of the `permissions` findings from coming back. Expect to start with an ignore-file and burn it down.
+
+**Third — structural**
+11. S6 — tag this repo, pin internal `uses:` by SHA, add `ref:` to the `validate-bucket-names` checkout.
+12. E5 — split `cdk-review` into parallel jobs (also completes S1's isolation).
+13. S8 — hash-pinned CI tool requirements file.
+14. E10 — decide the CI-artifact-vs-CD-rebuild question and document it.
+
+**Then** the remaining Low items, and reconcile the docs.
+
+---
+
+## Appendix — zizmor summary
+
+`zizmor 1.28.0 --persona=auditor --offline .github/` → 36 findings: 12 high, 11 medium, 13 low, 0 informational.
+
+| Audit | Count | Covered by |
+|---|---|---|
+| `unpinned-uses` | 12 | S6 |
+| `excessive-permissions` | 11 | S7; plus missing top-level `permissions:` blocks on `backup`, `gitleaks`, `self-test`, `repo-backup`, `validate-bucket-names`, both deploys and both reviews |
+| `undocumented-permissions` | 8 | — (comment each `id-token: write` / `pull-requests: write`; `python-ci.yml:93-100` already does this well) |
+| `concurrency-limits` | 4 | E1 |
+| `adhoc-packages` | 1 | S8 |
+| `dependabot-cooldown` | 1 | E14 (has an auto-fix) |
+
+The `excessive-permissions` warnings are worth a pass in their own right: eight workflows set `permissions` only at job level, leaving the workflow default in force. Adding `permissions: {}` at the top of each file and granting per-job is the pattern `access-analyzer-check.yml` half-implements (it sets workflow-level `id-token: write`, which zizmor flags as too broad at that scope — it should move to the job).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,9 @@
 pytest>=8.0
 boto3>=1.34
 PyYAML>=6.0
-yamllint>=1.35
+# Pinned exactly, same reasoning as ruff: version drift in a linter means local
+# and CI report different findings.
+yamllint==1.35.1
 # Pinned exactly, not >=: ruff changes its default rule set between minor
 # releases, and an unpinned linter means local and CI enforce different rules.
 # Bump deliberately, with ruff.toml reviewed alongside.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,11 @@
 # Dev/test dependencies for this repo's helper scripts and workflow linting.
+# Installed by both scripts/local-ci.sh and .github/workflows/self-test.yml, so
+# a local run and a CI run use the same tools.
 pytest>=8.0
 boto3>=1.34
+PyYAML>=6.0
 yamllint>=1.35
+ruff>=0.6
+# Static security audit for GitHub Actions. Advisory in the local gate: the repo
+# has known findings, tracked in .github/workflow-invariants-baseline.yml.
+zizmor>=1.28

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,12 @@ pytest>=8.0
 boto3>=1.34
 PyYAML>=6.0
 yamllint>=1.35
-ruff>=0.6
-# Static security audit for GitHub Actions. Advisory in the local gate: the repo
-# has known findings, tracked in .github/workflow-invariants-baseline.yml.
+# Pinned exactly, not >=: ruff changes its default rule set between minor
+# releases, and an unpinned linter means local and CI enforce different rules.
+# Bump deliberately, with ruff.toml reviewed alongside.
+ruff==0.16.0
+# Static security audit for GitHub Actions. Left unpinned deliberately, unlike
+# ruff above: zizmor is advisory in the gate, so a new rule in a new release
+# surfaces as information and can never turn CI red. Getting new audits for free
+# is the point.
 zizmor>=1.28

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,23 @@
+# Explicit ruff configuration.
+#
+# Without this file, `ruff check` enforces whatever the installed version
+# happens to default to — and that default changes between releases. Going from
+# 0.15 to 0.16 turned on RUF059, UP031, EXE001, PLW1510 and others, which turned
+# a green local run into a red CI run on code nobody had touched. Pinning the
+# version in requirements-dev.txt fixes the immediate divergence; declaring the
+# rule set here is what stops the next bump from moving the goalposts again.
+#
+# This is deliberately ruff's documented *stable default* selection, which is
+# what the existing code was written against. Broadening it (I, UP, RUF, SIM are
+# all reasonable next steps) means fixing the findings that appear, so it belongs
+# in its own change rather than riding along with a tooling PR.
+
+target-version = "py312"
+
+[lint]
+select = ["E4", "E7", "E9", "F"]
+
+[format]
+# Match the default explicitly rather than inheriting it.
+quote-style = "double"
+indent-style = "space"

--- a/scripts/check_workflow_invariants.py
+++ b/scripts/check_workflow_invariants.py
@@ -337,7 +337,7 @@ def _push_fires_on_main(trig: dict) -> bool:
         return True
 
     ignore = push.get("branches-ignore")
-    if ignore and _matches(MAIN, ignore):
+    if ignore is not None and _matches(MAIN, ignore):
         return False
 
     branches = push.get("branches")
@@ -349,6 +349,25 @@ def _push_fires_on_main(trig: dict) -> bool:
     return _matches(MAIN, branches)
 
 
+def _as_patterns(value) -> list[str]:
+    """Normalise a branch/tag filter to a list of pattern strings.
+
+    A scalar (`branches: main`) is invalid per GitHub's schema but is a common
+    hand-edit typo, and iterating a bare string yields characters — which made
+    `branches: main` evaluate to False, the opposite of the author's intent. A
+    non-iterable (`branches: 5`) previously raised TypeError. Treat a scalar as a
+    one-element list and stringify everything.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (str, int, float, bool)):
+        return [str(value)]
+    try:
+        return [str(v) for v in value]
+    except TypeError:
+        return [str(value)]
+
+
 def _matches(name: str, patterns) -> bool:
     """Does `name` survive a GitHub branch/tag filter list?
 
@@ -357,7 +376,7 @@ def _matches(name: str, patterns) -> bool:
     main". Evaluating in order is what distinguishes that from `["**"]`.
     """
     included = False
-    for raw in patterns:
+    for raw in _as_patterns(patterns):
         pat = str(raw)
         if pat.startswith("!"):
             if fnmatch(name, pat[1:]):

--- a/scripts/check_workflow_invariants.py
+++ b/scripts/check_workflow_invariants.py
@@ -80,6 +80,10 @@ CHECKS: dict[str, tuple[str, str]] = {
 FAIL_SEVERITIES = {"error"}
 
 
+class BaselineError(Exception):
+    """The baseline file exists but could not be understood."""
+
+
 @dataclass
 class Finding:
     check: str
@@ -333,7 +337,7 @@ def _push_fires_on_main(trig: dict) -> bool:
         return True
 
     ignore = push.get("branches-ignore")
-    if ignore and any(fnmatch(MAIN, str(p)) for p in ignore):
+    if ignore and _matches(MAIN, ignore):
         return False
 
     branches = push.get("branches")
@@ -342,8 +346,25 @@ def _push_fires_on_main(trig: dict) -> bool:
         # anything else (paths, no filter at all) fires on every branch.
         tag_only = any(k in push for k in ("tags", "tags-ignore"))
         return not tag_only
-    # Entries may be globs, so a literal membership test is not enough.
-    return any(fnmatch(MAIN, str(p)) for p in branches)
+    return _matches(MAIN, branches)
+
+
+def _matches(name: str, patterns) -> bool:
+    """Does `name` survive a GitHub branch/tag filter list?
+
+    Entries are globs and may be negated with a leading `!`; later entries
+    override earlier ones, so `["**", "!main"]` means "every branch except
+    main". Evaluating in order is what distinguishes that from `["**"]`.
+    """
+    included = False
+    for raw in patterns:
+        pat = str(raw)
+        if pat.startswith("!"):
+            if fnmatch(name, pat[1:]):
+                included = False
+        elif fnmatch(name, pat):
+            included = True
+    return included
 
 
 def check_triggers(src: Source) -> list[Finding]:
@@ -591,14 +612,25 @@ def load_baseline(path: Path) -> tuple[dict[str, int], dict]:
     """
     if not path.is_file():
         return {}, {}
-    doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    counts: dict[str, int] = {}
-    for a in doc.get("accepted") or []:
-        if "fingerprint" not in a:
-            continue
-        fp = str(a["fingerprint"])
-        counts[fp] = counts.get(fp, 0) + int(a.get("count", 1))
-    return counts, doc
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(doc, dict):
+            raise ValueError("top level is not a mapping")
+        counts: dict[str, int] = {}
+        for a in doc.get("accepted") or []:
+            if not isinstance(a, dict) or "fingerprint" not in a:
+                continue
+            fp = str(a["fingerprint"])
+            n = int(a.get("count", 1))
+            if n < 1:
+                raise ValueError(f"count must be >= 1, got {n!r} for {fp}")
+            counts[fp] = counts.get(fp, 0) + n
+        return counts, doc
+    except (yaml.YAMLError, ValueError, TypeError, AttributeError) as exc:
+        # Fail closed and legibly. Silently ignoring a broken baseline would
+        # accept nothing and bury the reason in a wall of findings; a traceback
+        # is correct-but-unreadable. Exit 2 is the documented "could not run".
+        raise BaselineError(f"{path}: {exc}") from exc
 
 
 def main() -> int:
@@ -649,7 +681,11 @@ def main() -> int:
         if args.baseline
         else root / ".github" / "workflow-invariants-baseline.yml"
     )
-    accepted, _ = ({}, {}) if args.strict else load_baseline(baseline_path)
+    try:
+        accepted, _ = ({}, {}) if args.strict else load_baseline(baseline_path)
+    except BaselineError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     # Consume the per-fingerprint budget in order; findings past it are new.
     remaining = dict(accepted)
     for f in findings:

--- a/scripts/check_workflow_invariants.py
+++ b/scripts/check_workflow_invariants.py
@@ -225,21 +225,41 @@ def check_checkout(src: Source) -> list[Finding]:
     return out
 
 
+def _pin_finding(src: Source, uses: str, context: str) -> Finding | None:
+    """Classify a single `uses:` value, or None if it needs no pin."""
+    uses = uses.strip()
+    if not uses or uses.startswith("./") or uses.startswith("docker://"):
+        return None
+    if "@" not in uses:
+        return Finding("WF003", src.rel, line_of(src.text, uses), f"{uses}{context}")
+    repo, ref = uses.rsplit("@", 1)
+    if SHA_RE.match(ref):
+        return None
+    check = "WF004" if repo.startswith(INTERNAL_PREFIX) else "WF003"
+    return Finding(check, src.rel, line_of(src.text, uses), f"{repo}@{ref}{context}")
+
+
 def check_pinning(src: Source) -> list[Finding]:
     """WF003 third-party pinned by SHA, WF004 internal pinned too."""
     out = []
     for _job, step in action_steps(src.doc):
-        uses = str(step.get("uses", "")).strip()
-        if not uses or uses.startswith("./") or uses.startswith("docker://"):
+        f = _pin_finding(src, str(step.get("uses", "")), "")
+        if f:
+            out.append(f)
+
+    # Job-level `uses:` — a reusable-workflow call. This is the highest-privilege
+    # composition in Actions, because it is the one that can carry
+    # `secrets: inherit`, yet it lives on the job rather than in `steps:` and so
+    # was previously invisible to the step walk above. An unpinned third-party
+    # reusable workflow here is strictly worse than an unpinned step action.
+    for name, job in jobs(src.doc).items():
+        if not isinstance(job, dict) or "uses" not in job:
             continue
-        if "@" not in uses:
-            out.append(Finding("WF003", src.rel, line_of(src.text, uses), uses))
-            continue
-        repo, ref = uses.rsplit("@", 1)
-        if SHA_RE.match(ref):
-            continue
-        check = "WF004" if repo.startswith(INTERNAL_PREFIX) else "WF003"
-        out.append(Finding(check, src.rel, line_of(src.text, uses), f"{repo}@{ref}"))
+        f = _pin_finding(
+            src, str(job["uses"]), f" (reusable workflow call in job '{name}')"
+        )
+        if f:
+            out.append(f)
 
     # A checkout of another repo without an explicit ref is the same mutable
     # dependency as `uses: ...@main`, and easier to miss.
@@ -297,9 +317,22 @@ def check_triggers(src: Source) -> list[Finding]:
                 "pull_request_target grants a write token to fork-authored code",
             )
         )
-    push = trig.get("push")
-    push_branches = (push or {}).get("branches", []) if isinstance(push, dict) else []
-    if "pull_request" in trig and "main" in (push_branches or []):
+    # WF014 has to treat three spellings of "also fires on main" as equivalent:
+    #   push: {branches: [main]}  — explicit
+    #   push:                     — no filter at all, so it fires on every branch
+    #                               including main (this is the easy one to miss)
+    #   on: [pull_request, push]  — list form, which triggers() maps to push=None
+    # Only an explicit branch list that excludes main is exempt.
+    push_fires_on_main = False
+    if "push" in trig:
+        push = trig["push"]
+        if isinstance(push, dict):
+            branches = push.get("branches")
+            # A filter naming other branches is fine; no filter means all branches.
+            push_fires_on_main = branches is None or "main" in branches
+        else:
+            push_fires_on_main = True
+    if "pull_request" in trig and push_fires_on_main:
         out.append(
             Finding(
                 "WF014",

--- a/scripts/check_workflow_invariants.py
+++ b/scripts/check_workflow_invariants.py
@@ -31,6 +31,7 @@ import argparse
 import json
 import re
 import sys
+from fnmatch import fnmatch
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -44,6 +45,8 @@ import yaml
 ORG = "Specter099"
 INTERNAL_PREFIX = f"{ORG}/.github"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# The protected branch every trigger rule here is written about.
+MAIN = "main"
 # Steps whose presence marks a workflow as running *checks* rather than deploying.
 CHECK_COMMAND_RE = re.compile(
     r"\b(ruff|pytest|bandit|pip-audit|checkov|cfn-lint|yamllint|eslint|vitest)\b"
@@ -304,6 +307,45 @@ def check_secrets_declared(src: Source) -> list[Finding]:
     ]
 
 
+def _push_fires_on_main(trig: dict) -> bool:
+    """Would this `on:` block run the workflow on a push to main?
+
+    Every spelling below means yes, and each was a real miss at some point:
+      push: {branches: [main]}      explicit
+      push:                         no filter at all → every branch
+      on: [pull_request, push]      list form; triggers() maps push to None
+      push: {paths: [...]}          a mapping with no branch filter → every branch
+      push: {branches: ["m*"]}      a glob that matches main
+
+    And these mean no:
+      push: {branches: [release/**]}   an explicit list that excludes main
+      push: {tags: ["v*"]}            tags-only never fires on a branch push, so
+                                      there is no merge-time double-run. This is
+                                      the common "PR checks + tag release" layout
+                                      and flagging it was a false positive.
+      push: {branches-ignore: [main]}  main explicitly excluded
+    """
+    if "push" not in trig:
+        return False
+    push = trig["push"]
+    if not isinstance(push, dict):
+        # `push:` (None) or a bare string/list form — no filtering at all.
+        return True
+
+    ignore = push.get("branches-ignore")
+    if ignore and any(fnmatch(MAIN, str(p)) for p in ignore):
+        return False
+
+    branches = push.get("branches")
+    if branches is None:
+        # No branch filter. A tags-only trigger never fires on a branch push;
+        # anything else (paths, no filter at all) fires on every branch.
+        tag_only = any(k in push for k in ("tags", "tags-ignore"))
+        return not tag_only
+    # Entries may be globs, so a literal membership test is not enough.
+    return any(fnmatch(MAIN, str(p)) for p in branches)
+
+
 def check_triggers(src: Source) -> list[Finding]:
     """WF006 pull_request_target, WF014 pull_request + push:main together."""
     out = []
@@ -317,22 +359,7 @@ def check_triggers(src: Source) -> list[Finding]:
                 "pull_request_target grants a write token to fork-authored code",
             )
         )
-    # WF014 has to treat three spellings of "also fires on main" as equivalent:
-    #   push: {branches: [main]}  — explicit
-    #   push:                     — no filter at all, so it fires on every branch
-    #                               including main (this is the easy one to miss)
-    #   on: [pull_request, push]  — list form, which triggers() maps to push=None
-    # Only an explicit branch list that excludes main is exempt.
-    push_fires_on_main = False
-    if "push" in trig:
-        push = trig["push"]
-        if isinstance(push, dict):
-            branches = push.get("branches")
-            # A filter naming other branches is fine; no filter means all branches.
-            push_fires_on_main = branches is None or "main" in branches
-        else:
-            push_fires_on_main = True
-    if "pull_request" in trig and push_fires_on_main:
+    if "pull_request" in trig and _push_fires_on_main(trig):
         out.append(
             Finding(
                 "WF014",
@@ -552,12 +579,26 @@ def collect(root: Path) -> tuple[list[Finding], list[str]]:
     return findings, errors
 
 
-def load_baseline(path: Path) -> tuple[set[str], dict]:
+def load_baseline(path: Path) -> tuple[dict[str, int], dict]:
+    """Return {fingerprint: accepted_count}.
+
+    Counts, not a bare set: two genuinely distinct violations in the same file
+    can share a fingerprint (same check, same path, same detail text — e.g. a
+    second `echo "x<<EOF"` added to a workflow that already has a baselined
+    one). With a set, the new one was silently absorbed by the old entry. An
+    entry accepts `count` findings (default 1); anything beyond that is new and
+    blocks.
+    """
     if not path.is_file():
-        return set(), {}
+        return {}, {}
     doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    accepted = doc.get("accepted") or []
-    return {str(a["fingerprint"]) for a in accepted if "fingerprint" in a}, doc
+    counts: dict[str, int] = {}
+    for a in doc.get("accepted") or []:
+        if "fingerprint" not in a:
+            continue
+        fp = str(a["fingerprint"])
+        counts[fp] = counts.get(fp, 0) + int(a.get("count", 1))
+    return counts, doc
 
 
 def main() -> int:
@@ -608,9 +649,14 @@ def main() -> int:
         if args.baseline
         else root / ".github" / "workflow-invariants-baseline.yml"
     )
-    accepted, _ = (set(), {}) if args.strict else load_baseline(baseline_path)
+    accepted, _ = ({}, {}) if args.strict else load_baseline(baseline_path)
+    # Consume the per-fingerprint budget in order; findings past it are new.
+    remaining = dict(accepted)
     for f in findings:
-        f.accepted = f.fingerprint in accepted
+        budget = remaining.get(f.fingerprint, 0)
+        if budget > 0:
+            f.accepted = True
+            remaining[f.fingerprint] = budget - 1
 
     fail_sev = FAIL_SEVERITIES | ({"warn"} if args.fail_on_warn else set())
     blocking = [f for f in findings if not f.accepted and f.severity in fail_sev]

--- a/scripts/check_workflow_invariants.py
+++ b/scripts/check_workflow_invariants.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""
+check_workflow_invariants.py
+
+Structural checks for GitHub Actions workflows and composite actions that
+off-the-shelf linters don't cover. yamllint checks formatting, actionlint
+checks syntax and expression validity, zizmor checks generic security
+patterns — this script checks the conventions specific to this org.
+
+Each check has an ID (WF0xx), a severity, and a one-line rationale. Findings
+whose fingerprint appears in the baseline file are reported as ACCEPTED and
+don't affect the exit code, so known-outstanding work doesn't block commits
+while new violations still fail.
+
+Usage:
+    python scripts/check_workflow_invariants.py                    # this repo
+    python scripts/check_workflow_invariants.py --path ../other    # a caller repo
+    python scripts/check_workflow_invariants.py --strict           # ignore baseline
+    python scripts/check_workflow_invariants.py --list-checks
+    python scripts/check_workflow_invariants.py --format=github    # CI annotations
+
+Exit codes:
+    0 — no unaccepted findings at or above the fail threshold
+    1 — one or more unaccepted findings
+    2 — could not run (unparseable YAML, missing path)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Conventions this script enforces. Keep the rationale text short — it is
+# printed verbatim next to every finding.
+# ---------------------------------------------------------------------------
+
+ORG = "Specter099"
+INTERNAL_PREFIX = f"{ORG}/.github"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# Steps whose presence marks a workflow as running *checks* rather than deploying.
+CHECK_COMMAND_RE = re.compile(
+    r"\b(ruff|pytest|bandit|pip-audit|checkov|cfn-lint|yamllint|eslint|vitest)\b"
+)
+# Expression contexts an attacker can influence via a PR.
+UNTRUSTED_CONTEXT_RE = re.compile(
+    r"\$\{\{\s*(inputs\.|github\.event\.|github\.head_ref|github\.ref_name)"
+)
+
+CHECKS: dict[str, tuple[str, str]] = {
+    # id:      (severity, rationale)
+    "WF001": ("error", "every job must set timeout-minutes (default is 6 hours)"),
+    "WF002": ("error", "actions/checkout must set persist-credentials: false"),
+    "WF003": ("error", "third-party actions must be pinned to a 40-char commit SHA"),
+    "WF004": ("warn", "internal actions/workflows must be pinned, not @main"),
+    "WF005": ("error", "workflow_call must declare every secret it references"),
+    "WF006": ("error", "pull_request_target is not permitted in this org"),
+    "WF007": ("warn", "GITHUB_OUTPUT heredoc must use a randomised delimiter"),
+    "WF008": ("warn", "PR-check workflows must define a concurrency group"),
+    "WF009": ("error", "no ${{ }} interpolation of untrusted context inside run:"),
+    "WF010": ("error", "every job must declare permissions"),
+    "WF011": ("warn", "declared inputs should be referenced somewhere in the file"),
+    "WF012": ("error", "README usage examples must only pass declared inputs"),
+    "WF013": ("error", "deploy workflows must not run checks (checks belong in CI)"),
+    "WF014": (
+        "error",
+        "a workflow must not trigger on both pull_request and push:main",
+    ),
+}
+
+FAIL_SEVERITIES = {"error"}
+
+
+@dataclass
+class Finding:
+    check: str
+    path: str
+    line: int
+    detail: str
+    accepted: bool = False
+
+    @property
+    def severity(self) -> str:
+        return CHECKS[self.check][0]
+
+    @property
+    def rationale(self) -> str:
+        return CHECKS[self.check][1]
+
+    @property
+    def fingerprint(self) -> str:
+        """Stable identity for baselining — deliberately excludes the line
+        number so that unrelated edits above a finding don't un-baseline it."""
+        return f"{self.check}:{self.path}:{self.detail}"
+
+
+@dataclass
+class Source:
+    path: Path
+    rel: str
+    text: str
+    doc: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# YAML helpers
+# ---------------------------------------------------------------------------
+
+
+def load(path: Path, root: Path) -> Source:
+    text = path.read_text(encoding="utf-8")
+    doc = yaml.safe_load(text)
+    if not isinstance(doc, dict):
+        raise ValueError(f"{path}: top level is not a mapping")
+    return Source(path=path, rel=str(path.relative_to(root)), text=text, doc=doc)
+
+
+def triggers(doc: dict) -> dict:
+    """Return the `on:` block.
+
+    PyYAML follows YAML 1.1, where a bare `on:` key is parsed as the boolean
+    True. Workflows in this repo use both `on:` and quoted `"on":`, so both
+    spellings have to be handled.
+    """
+    for key in (True, "on", "On", "ON"):
+        if key in doc:
+            value = doc[key]
+            if isinstance(value, dict):
+                return value
+            if isinstance(value, str):
+                return {value: None}
+            if isinstance(value, list):
+                return dict.fromkeys(value)
+    return {}
+
+
+def jobs(doc: dict) -> dict:
+    got = doc.get("jobs")
+    return got if isinstance(got, dict) else {}
+
+
+def steps_of(job: dict) -> list[dict]:
+    got = job.get("steps")
+    return [s for s in got if isinstance(s, dict)] if isinstance(got, list) else []
+
+
+def action_steps(doc: dict) -> list[tuple[str, dict]]:
+    """All steps with a `uses:`, from a workflow or a composite action, as
+    (job_name_or_'runs', step) pairs."""
+    out: list[tuple[str, dict]] = []
+    for name, job in jobs(doc).items():
+        if isinstance(job, dict):
+            out += [(str(name), s) for s in steps_of(job)]
+    runs = doc.get("runs")
+    if isinstance(runs, dict):
+        out += [("runs", s) for s in steps_of(runs)]
+    return out
+
+
+def line_of(text: str, *needles: str, default: int = 1) -> int:
+    """First 1-indexed line containing every needle. Keeps the data model
+    clean — PyYAML discards positions, and re-finding them is cheap."""
+    for i, line in enumerate(text.splitlines(), 1):
+        if all(n in line for n in needles):
+            return i
+    return default
+
+
+def is_reusable(doc: dict) -> bool:
+    return "workflow_call" in triggers(doc)
+
+
+def is_composite(doc: dict) -> bool:
+    runs = doc.get("runs")
+    return isinstance(runs, dict) and runs.get("using") == "composite"
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def check_jobs(src: Source) -> list[Finding]:
+    """WF001 timeout-minutes, WF010 permissions."""
+    out = []
+    for name, job in jobs(src.doc).items():
+        if not isinstance(job, dict):
+            continue
+        # A job that only calls a reusable workflow can't set timeout-minutes
+        # or its own permissions — those live in the callee.
+        if "uses" in job:
+            continue
+        ln = line_of(src.text, f"{name}:")
+        if "timeout-minutes" not in job:
+            out.append(Finding("WF001", src.rel, ln, f"job '{name}'"))
+        if "permissions" not in job and "permissions" not in src.doc:
+            out.append(Finding("WF010", src.rel, ln, f"job '{name}'"))
+    return out
+
+
+def check_checkout(src: Source) -> list[Finding]:
+    """WF002 — a checkout that leaves the token on disk lets any later step
+    (including a dependency's build hook) push with it."""
+    out = []
+    for _job, step in action_steps(src.doc):
+        uses = str(step.get("uses", ""))
+        if not uses.startswith("actions/checkout@"):
+            continue
+        with_ = step.get("with") or {}
+        if str(with_.get("persist-credentials", "")).lower() != "false":
+            out.append(
+                Finding(
+                    "WF002",
+                    src.rel,
+                    line_of(src.text, uses),
+                    f"uses {uses.split('@')[0]}",
+                )
+            )
+    return out
+
+
+def check_pinning(src: Source) -> list[Finding]:
+    """WF003 third-party pinned by SHA, WF004 internal pinned too."""
+    out = []
+    for _job, step in action_steps(src.doc):
+        uses = str(step.get("uses", "")).strip()
+        if not uses or uses.startswith("./") or uses.startswith("docker://"):
+            continue
+        if "@" not in uses:
+            out.append(Finding("WF003", src.rel, line_of(src.text, uses), uses))
+            continue
+        repo, ref = uses.rsplit("@", 1)
+        if SHA_RE.match(ref):
+            continue
+        check = "WF004" if repo.startswith(INTERNAL_PREFIX) else "WF003"
+        out.append(Finding(check, src.rel, line_of(src.text, uses), f"{repo}@{ref}"))
+
+    # A checkout of another repo without an explicit ref is the same mutable
+    # dependency as `uses: ...@main`, and easier to miss.
+    for _job, step in action_steps(src.doc):
+        uses = str(step.get("uses", ""))
+        if not uses.startswith("actions/checkout@"):
+            continue
+        with_ = step.get("with") or {}
+        repo = str(with_.get("repository", ""))
+        if repo and not with_.get("ref"):
+            out.append(
+                Finding(
+                    "WF004",
+                    src.rel,
+                    line_of(src.text, f"repository: {repo}"),
+                    f"checkout of {repo} with no ref (implicit default branch)",
+                )
+            )
+    return out
+
+
+def check_secrets_declared(src: Source) -> list[Finding]:
+    """WF005 — an undeclared secret is only populated via `secrets: inherit`,
+    which hands the callee every secret the caller holds."""
+    if not is_reusable(src.doc):
+        return []
+    call = triggers(src.doc).get("workflow_call") or {}
+    declared = set((call.get("secrets") or {}).keys())
+    referenced = {
+        m
+        for m in re.findall(r"secrets\.([A-Za-z_][A-Za-z0-9_]*)", src.text)
+        if m != "GITHUB_TOKEN"  # always injected, never declarable
+    }
+    return [
+        Finding(
+            "WF005",
+            src.rel,
+            line_of(src.text, f"secrets.{name}"),
+            f"references secrets.{name} but does not declare it",
+        )
+        for name in sorted(referenced - declared)
+    ]
+
+
+def check_triggers(src: Source) -> list[Finding]:
+    """WF006 pull_request_target, WF014 pull_request + push:main together."""
+    out = []
+    trig = triggers(src.doc)
+    if "pull_request_target" in trig:
+        out.append(
+            Finding(
+                "WF006",
+                src.rel,
+                line_of(src.text, "pull_request_target"),
+                "pull_request_target grants a write token to fork-authored code",
+            )
+        )
+    push = trig.get("push")
+    push_branches = (push or {}).get("branches", []) if isinstance(push, dict) else []
+    if "pull_request" in trig and "main" in (push_branches or []):
+        out.append(
+            Finding(
+                "WF014",
+                src.rel,
+                line_of(src.text, "push:"),
+                "triggers on pull_request and push:main — checks double-run at merge",
+            )
+        )
+    return out
+
+
+def check_output_heredoc(src: Source) -> list[Finding]:
+    """WF007 — a fixed heredoc delimiter on command output lets that command's
+    text terminate the block early and forge later step outputs."""
+    out = []
+    for m in re.finditer(
+        r'^\s*echo "([A-Za-z0-9_-]+)<<([A-Za-z0-9_]+)"', src.text, re.M
+    ):
+        name, delim = m.group(1), m.group(2)
+        if delim in {"EOF", "END", "DELIM", "EOT"}:
+            out.append(
+                Finding(
+                    "WF007",
+                    src.rel,
+                    src.text[: m.start()].count("\n") + 1,
+                    f"output '{name}' uses fixed heredoc delimiter '{delim}'",
+                )
+            )
+    return out
+
+
+def check_concurrency(src: Source) -> list[Finding]:
+    """WF008 — without cancel-in-progress, every push to a PR runs a full
+    duplicate pipeline to completion."""
+    name = Path(src.rel).name
+    is_check = "review" in name or name in {"python-ci.yml", "self-test.yml"}
+    if not is_check:
+        return []
+    if "concurrency" in src.doc:
+        return []
+    missing = [
+        n
+        for n, job in jobs(src.doc).items()
+        if isinstance(job, dict) and "concurrency" not in job
+    ]
+    return [
+        Finding("WF008", src.rel, line_of(src.text, f"{n}:"), f"job '{n}'")
+        for n in missing
+    ]
+
+
+def check_run_interpolation(src: Source) -> list[Finding]:
+    """WF009 — the script-injection check. Untrusted context interpolated into
+    a run: body is substituted before the shell parses it."""
+    out = []
+    for job_name, step in action_steps(src.doc):
+        run = step.get("run")
+        if not isinstance(run, str):
+            continue
+        for m in UNTRUSTED_CONTEXT_RE.finditer(run):
+            expr = run[m.start() : run.find("}}", m.start()) + 2]
+            out.append(
+                Finding(
+                    "WF009",
+                    src.rel,
+                    line_of(src.text, expr.strip()),
+                    f"job '{job_name}' interpolates {expr.strip()} into run:",
+                )
+            )
+    return out
+
+
+def check_unused_inputs(src: Source) -> list[Finding]:
+    """WF011 — a declared-but-unreferenced input is either dead or a typo at
+    the point of use."""
+    if is_reusable(src.doc):
+        spec = (triggers(src.doc).get("workflow_call") or {}).get("inputs") or {}
+    elif is_composite(src.doc):
+        spec = src.doc.get("inputs") or {}
+    else:
+        return []
+    out = []
+    for name in spec:
+        # inputs.foo-bar, inputs['foo-bar'], and INPUT_FOO_BAR (composite env)
+        env_name = "INPUT_" + str(name).upper().replace("-", "_")
+        patterns = (
+            f"inputs.{name}",
+            f"inputs['{name}']",
+            f'inputs["{name}"]',
+            env_name,
+        )
+        if not any(p in src.text for p in patterns):
+            out.append(
+                Finding(
+                    "WF011",
+                    src.rel,
+                    line_of(src.text, f"{name}:"),
+                    f"input '{name}' is declared but never referenced",
+                )
+            )
+    return out
+
+
+def check_no_checks_in_deploy(src: Source) -> list[Finding]:
+    """WF013 — encodes the repo's 'all checks in CI, CD only deploys' model."""
+    if "deploy" not in Path(src.rel).name:
+        return []
+    out = []
+    for job_name, step in action_steps(src.doc):
+        run = step.get("run")
+        blob = f"{step.get('name', '')} {run if isinstance(run, str) else ''}"
+        m = CHECK_COMMAND_RE.search(blob)
+        # `npm run build` is a deploy-time artifact build, not a check.
+        if m and "run build" not in blob:
+            out.append(
+                Finding(
+                    "WF013",
+                    src.rel,
+                    line_of(src.text, m.group(0)),
+                    f"job '{job_name}' runs '{m.group(0)}' in a deploy workflow",
+                )
+            )
+    return out
+
+
+def check_readme_examples(root: Path, workflows: dict[str, Source]) -> list[Finding]:
+    """WF012 — every input in a README usage example must exist. GitHub rejects
+    unknown inputs to a reusable workflow, so a stale example is a broken
+    copy-paste for whoever follows the docs.
+    """
+    readme = root / "README.md"
+    if not readme.is_file():
+        return []
+    text = readme.read_text(encoding="utf-8")
+    out = []
+    # Each `uses: <org>/.github/.github/workflows/<name>.yml@ref` followed by an
+    # optional `with:` block whose keys should all be declared inputs.
+    pattern = re.compile(
+        r"uses:\s*\S+/\.github/workflows/(?P<wf>[\w.-]+\.yml)@\S+"
+        r"(?P<rest>(?:\n[ \t]+\S.*)*)",
+    )
+    for m in pattern.finditer(text):
+        wf, rest = m.group("wf"), m.group("rest")
+        src = workflows.get(wf)
+        if src is None:
+            out.append(
+                Finding(
+                    "WF012",
+                    "README.md",
+                    text[: m.start()].count("\n") + 1,
+                    f"documents {wf}, which does not exist",
+                )
+            )
+            continue
+        declared = set(
+            ((triggers(src.doc).get("workflow_call") or {}).get("inputs") or {}).keys()
+        )
+        if "with:" not in rest:
+            continue
+        after_with = rest.split("with:", 1)[1]
+        for km in re.finditer(r"^\s+([a-zA-Z][\w-]*):", after_with, re.M):
+            key = km.group(1)
+            if key not in declared:
+                out.append(
+                    Finding(
+                        "WF012",
+                        "README.md",
+                        line_of(text, f"{key}:", default=1),
+                        f"{wf} example passes '{key}', which is not a declared input",
+                    )
+                )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+PER_FILE_CHECKS = (
+    check_jobs,
+    check_checkout,
+    check_pinning,
+    check_secrets_declared,
+    check_triggers,
+    check_output_heredoc,
+    check_concurrency,
+    check_run_interpolation,
+    check_unused_inputs,
+    check_no_checks_in_deploy,
+)
+
+
+def collect(root: Path) -> tuple[list[Finding], list[str]]:
+    """Run every check. Returns (findings, hard_errors)."""
+    findings: list[Finding] = []
+    errors: list[str] = []
+    workflows: dict[str, Source] = {}
+
+    paths = sorted((root / ".github" / "workflows").glob("*.y*ml"))
+    paths += sorted((root / ".github" / "actions").glob("*/action.y*ml"))
+    if not paths:
+        errors.append(f"no workflows or actions found under {root}/.github")
+        return findings, errors
+
+    for path in paths:
+        try:
+            src = load(path, root)
+        except (yaml.YAMLError, ValueError) as exc:
+            errors.append(f"{path.relative_to(root)}: {exc}")
+            continue
+        if "workflows" in path.parts:
+            workflows[path.name] = src
+        for check in PER_FILE_CHECKS:
+            findings += check(src)
+
+    findings += check_readme_examples(root, workflows)
+    return findings, errors
+
+
+def load_baseline(path: Path) -> tuple[set[str], dict]:
+    if not path.is_file():
+        return set(), {}
+    doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    accepted = doc.get("accepted") or []
+    return {str(a["fingerprint"]) for a in accepted if "fingerprint" in a}, doc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[1])
+    parser.add_argument("--path", default=".", help="repo root to check (default: .)")
+    parser.add_argument(
+        "--baseline",
+        default=None,
+        help="baseline YAML (default: <path>/.github/workflow-invariants-baseline.yml)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="ignore the baseline — every finding counts",
+    )
+    parser.add_argument(
+        "--fail-on-warn",
+        action="store_true",
+        help="treat warn-severity findings as failures too",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "github", "json"),
+        default="text",
+        help="github emits ::error/::warning annotations",
+    )
+    parser.add_argument("--list-checks", action="store_true", help="list check IDs")
+    args = parser.parse_args()
+
+    if args.list_checks:
+        for cid, (sev, why) in CHECKS.items():
+            print(f"{cid}  {sev:<5}  {why}")
+        return 0
+
+    root = Path(args.path).resolve()
+    if not root.is_dir():
+        print(f"error: --path not found: {root}", file=sys.stderr)
+        return 2
+
+    findings, errors = collect(root)
+    for err in errors:
+        print(f"error: {err}", file=sys.stderr)
+    if errors:
+        return 2
+
+    baseline_path = (
+        Path(args.baseline)
+        if args.baseline
+        else root / ".github" / "workflow-invariants-baseline.yml"
+    )
+    accepted, _ = (set(), {}) if args.strict else load_baseline(baseline_path)
+    for f in findings:
+        f.accepted = f.fingerprint in accepted
+
+    fail_sev = FAIL_SEVERITIES | ({"warn"} if args.fail_on_warn else set())
+    blocking = [f for f in findings if not f.accepted and f.severity in fail_sev]
+    advisory = [f for f in findings if not f.accepted and f.severity not in fail_sev]
+    tolerated = [f for f in findings if f.accepted]
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "blocking": [vars(f) | {"severity": f.severity} for f in blocking],
+                    "advisory": [vars(f) | {"severity": f.severity} for f in advisory],
+                    "accepted": len(tolerated),
+                },
+                indent=2,
+            )
+        )
+        return 1 if blocking else 0
+
+    def emit(f: Finding, kind: str) -> None:
+        if args.format == "github":
+            level = "error" if kind == "blocking" else "warning"
+            print(
+                f"::{level} file={f.path},line={f.line},title={f.check}::"
+                f"{f.detail} — {f.rationale}"
+            )
+        else:
+            mark = {"blocking": "✗", "advisory": "!", "accepted": "·"}[kind]
+            print(f"  {mark} {f.check} {f.path}:{f.line}  {f.detail}")
+
+    if blocking:
+        print(f"\n{len(blocking)} blocking finding(s):")
+        for f in sorted(blocking, key=lambda f: (f.check, f.path, f.line)):
+            emit(f, "blocking")
+            print(f"      → {f.rationale}")
+    if advisory:
+        print(f"\n{len(advisory)} advisory finding(s) (warn severity):")
+        for f in sorted(advisory, key=lambda f: (f.check, f.path, f.line)):
+            emit(f, "advisory")
+    if tolerated and args.format == "text":
+        print(
+            f"\n{len(tolerated)} accepted via baseline (use --strict to show as new):"
+        )
+        by_check: dict[str, int] = {}
+        for f in tolerated:
+            by_check[f.check] = by_check.get(f.check, 0) + 1
+        for cid in sorted(by_check):
+            print(f"  · {cid} ×{by_check[cid]}  {CHECKS[cid][1]}")
+
+    if not blocking:
+        print(f"\nOK — no blocking findings ({len(findings)} total, checked {root}).")
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -190,7 +190,10 @@ fi
 # yamllint is a hard dependency (pinned in requirements-dev.txt and run by CI),
 # not an optional extra — its absence is `missing`, not `skip`.
 if have yamllint; then
-  YAMLLINT_ARGS=(-c .yamllint.yml)
+  # --strict so warning-level findings exit non-zero too. Without it a
+  # warning exits 0 and run() discards the output — the same muted-findings
+  # shape as B-1/B-2, just inside a third-party tool's pass contract.
+  YAMLLINT_ARGS=(-c .yamllint.yml --strict)
   [ "$FORMAT" = "github" ] && YAMLLINT_ARGS+=(-f github)
   run "yamllint" required yamllint "${YAMLLINT_ARGS[@]}" .github/
 else
@@ -245,7 +248,7 @@ elif have actionlint; then
     *) say "${YELLOW}  note:${RESET} actionlint on PATH is ${actual:-unknown}, CI uses ${ACTIONLINT_VERSION} — findings may differ" ;;
   esac
   run "actionlint" required actionlint -no-color -shellcheck= .github/workflows/*.yml
-elif have go && [ "$FAST" = 0 ]; then
+elif have go; then
   say "${DIM}  installing actionlint (one-off, via go install)...${RESET}"
   if GOBIN="$(go env GOPATH)/bin" go install \
        "github.com/rhysd/actionlint/cmd/actionlint@$ACTIONLINT_VERSION" >/dev/null 2>&1; then

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -235,7 +235,10 @@ run "workflow invariants" required \
 # what CI installs, rather than letting the drift be silent.
 ACTIONLINT_VERSION="v1.7.7"
 
-if have actionlint; then
+if [ "$FAST" = 1 ]; then
+  # Explicit opt-out; counts as skipped, so PASS stays reachable.
+  skip "actionlint" "--fast"
+elif have actionlint; then
   actual="$(actionlint --version 2>/dev/null | head -1)"
   case "$actual" in
     "${ACTIONLINT_VERSION#v}"|"$ACTIONLINT_VERSION") : ;;
@@ -251,9 +254,6 @@ elif have go && [ "$FAST" = 0 ]; then
   else
     missing "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@$ACTIONLINT_VERSION"
   fi
-elif [ "$FAST" = 1 ]; then
-  # An explicit --fast opt-out is a choice, not an absent dependency.
-  skip "actionlint" "--fast"
 else
   missing "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@$ACTIONLINT_VERSION"
 fi
@@ -299,10 +299,16 @@ if [ -n "$CDK_PROJECT" ]; then
         python3 scripts/validate_bucket_names.py --template-dir "$OUT"
       # check_no_public_access calls the Access Analyzer API, so it needs real
       # credentials. Probe first rather than emitting a traceback.
+      #
+      # Deliberately NOT --no-fail-on-public-access. That flag makes the script
+      # exit 0 when it finds public access, and `run` prints ✓ and discards the
+      # output of anything that exits 0 — so detected public access rendered as
+      # an affirmative green tick with the findings thrown away. `advisory`
+      # already guarantees this stage cannot block the gate; a non-zero exit is
+      # exactly what makes the advisory path *show* the findings.
       if have aws && aws sts get-caller-identity >/dev/null 2>&1; then
         run "access analyzer" advisory \
-          python3 scripts/check_no_public_access.py \
-            --template-dir "$OUT" --no-fail-on-public-access
+          python3 scripts/check_no_public_access.py --template-dir "$OUT"
       else
         skip "access analyzer" "no usable AWS credentials (needs a real API call)"
       fi

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -17,7 +17,12 @@
 # block. Missing optional tools SKIP with an install hint rather than failing,
 # so a fresh clone is usable immediately.
 
-set -uo pipefail
+# pipefail only, deliberately no `-u`: under `set -u`, bash 3.2 — still
+# /bin/bash on macOS — treats `${#arr[@]}` on an empty array as an unbound
+# variable and aborts, which the summary block would hit on every clean run.
+# Every variable here is explicitly initialised, so `-u` buys little.
+# No `-e` either: `run` inspects each stage's exit code itself.
+set -o pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 2
@@ -142,8 +147,8 @@ zizmor_brief() {
 # ===========================================================================
 hdr "CI"
 
-if [ "$FIX" = 1 ] && have ruff; then
-  run "ruff format (--fix)" required ruff format scripts/ tests/
+if [ "$FIX" = 1 ] && python3 -c 'import ruff' 2>/dev/null; then
+  run "ruff format (--fix)" required python3 -m ruff format scripts/ tests/
 fi
 
 if have yamllint; then
@@ -152,11 +157,18 @@ else
   skip "yamllint" "pip install -r requirements-dev.txt"
 fi
 
-if have ruff; then
+# Same `python3 -m` reasoning as pytest below, and it bit harder here: a
+# PATH-shadowed ruff 0.15 passed locally while CI's pinned 0.16 failed on 22
+# findings, because the two ship different default rule sets. ruff.toml now
+# declares the rules; this makes sure the pinned binary is the one applying them.
+if python3 -c 'import ruff' 2>/dev/null; then
+  run "ruff check" required python3 -m ruff check scripts/ tests/
+  run "ruff format --check" required python3 -m ruff format --check scripts/ tests/
+elif have ruff; then
   run "ruff check" required ruff check scripts/ tests/
   run "ruff format --check" required ruff format --check scripts/ tests/
 else
-  skip "ruff" "pip install ruff"
+  skip "ruff" "pip install -r requirements-dev.txt"
 fi
 
 # Invoke via `python3 -m` so the tests run against the same interpreter that

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -13,9 +13,14 @@
 #   ./scripts/local-ci.sh --cdk-project ../bitwarden-cdk
 #   ./scripts/local-ci.sh --install-hook       # wire up as a pre-commit hook
 #
-# Exit 0 only if every required stage passed. Advisory stages report but never
-# block. Missing optional tools SKIP with an install hint rather than failing,
-# so a fresh clone is usable immediately.
+# Exit 0 only if every required stage actually ran and passed.
+#   required  yamllint, ruff, pytest, workflow invariants, actionlint — these are
+#             what CI runs. If one cannot run because its tool is absent, the
+#             verdict is INCOMPLETE (exit 1), never PASS: "I did not check" is
+#             not "it is fine", and claiming otherwise recreates the local/CI
+#             divergence this gate exists to prevent.
+#   advisory  zizmor, act — report findings, never block.
+#   optional  cdk, aws — only used by the CD stages, skipped when absent.
 
 # pipefail only, deliberately no `-u`: under `set -u`, bash 3.2 — still
 # /bin/bash on macOS — treats `${#arr[@]}` on an empty array as an unbound
@@ -41,10 +46,13 @@ usage() {
 Options:
   --fix               auto-fix what is mechanically fixable (ruff format)
   --strict            invariants: ignore the baseline and show every finding
-  --fast              skip the slower advisory stages (zizmor)
+  --fast              skip zizmor and actionlint, as an explicit opt-out
+                      (they count as skipped, not missing, so PASS is possible)
   --cdk-project DIR   also run the CD-side checks against a CDK project
   --act               execute self-test.yml locally under `act` (needs Docker)
-  --format github     emit ::error/::warning annotations (for use in CI)
+  --format github     emit ::error/::warning annotations from the stages that
+                      support them (yamllint, ruff, invariants); pytest output
+                      stays plain text. Exit codes are unaffected.
   --install-hook      install this script as .git/hooks/pre-commit
   --quiet             only print the summary and failures
   -h, --help          this text
@@ -66,7 +74,15 @@ while [ $# -gt 0 ]; do
       cat > "$hook" <<'HOOK'
 #!/usr/bin/env bash
 # Installed by scripts/local-ci.sh --install-hook
-exec "$(git rev-parse --show-toplevel)/scripts/local-ci.sh" --quiet
+root="$(git rev-parse --show-toplevel)"
+# This gate runs against the WORKING TREE, not the staged index. Auto-stashing
+# to isolate the index can lose work when a hook is interrupted, so instead we
+# say so plainly when the two differ — then a green gate is not misread as
+# "exactly what I am committing is green".
+if ! git diff --quiet; then
+  printf 'local-ci: note — unstaged changes present, so this gate checked the working tree, not just what is staged.\n' >&2
+fi
+exec "$root/scripts/local-ci.sh" --quiet
 HOOK
       chmod +x "$hook"
       echo "Installed pre-commit hook → $hook"
@@ -87,7 +103,7 @@ else
   BOLD=""; RED=""; GREEN=""; YELLOW=""; DIM=""; RESET=""
 fi
 
-FAILED=() PASSED=() SKIPPED=() ADVISORY=()
+FAILED=() PASSED=() SKIPPED=() ADVISORY=() MISSING=()
 START=$SECONDS
 
 say() { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
@@ -115,9 +131,23 @@ run() {
   return 0
 }
 
+# Two kinds of not-run, and conflating them was a real bug: the gate printed
+# "PASS — Safe to commit" having never run yamllint or actionlint, both of which
+# CI *does* run. A missing optional tool is fine; a missing required one means
+# the gate did not actually run, and it must not claim otherwise.
+#
+# skip     — optional stage (zizmor, act, cdk) or an explicit --fast opt-out.
+#            Verdict stays PASS.
+# missing  — required stage whose tool is absent. Verdict becomes INCOMPLETE and
+#            the exit code is non-zero, because "I didn't check" is not "it's fine".
 skip() {
   SKIPPED+=("$1")
   say "${DIM}∅ $1 — $2${RESET}"
+}
+
+missing() {
+  MISSING+=("$1")
+  printf '%s⚠%s %s — required stage not run: %s\n' "$YELLOW" "$RESET" "$1" "$2"
 }
 
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -149,12 +179,22 @@ hdr "CI"
 
 if [ "$FIX" = 1 ] && python3 -c 'import ruff' 2>/dev/null; then
   run "ruff format (--fix)" required python3 -m ruff format scripts/ tests/
+  # The format --check stage below will now pass by construction, so flag that
+  # files on disk changed and are not staged — otherwise PASS reads as "nothing
+  # needed doing".
+  if ! git diff --quiet -- scripts/ tests/ 2>/dev/null; then
+    say "${YELLOW}  note:${RESET} --fix rewrote files; they are unstaged. Review with: git diff scripts/ tests/"
+  fi
 fi
 
+# yamllint is a hard dependency (pinned in requirements-dev.txt and run by CI),
+# not an optional extra — its absence is `missing`, not `skip`.
 if have yamllint; then
-  run "yamllint" required yamllint -c .yamllint.yml .github/
+  YAMLLINT_ARGS=(-c .yamllint.yml)
+  [ "$FORMAT" = "github" ] && YAMLLINT_ARGS+=(-f github)
+  run "yamllint" required yamllint "${YAMLLINT_ARGS[@]}" .github/
 else
-  skip "yamllint" "pip install -r requirements-dev.txt"
+  missing "yamllint" "pip install -r requirements-dev.txt"
 fi
 
 # Same `python3 -m` reasoning as pytest below, and it bit harder here: a
@@ -162,13 +202,12 @@ fi
 # findings, because the two ship different default rule sets. ruff.toml now
 # declares the rules; this makes sure the pinned binary is the one applying them.
 if python3 -c 'import ruff' 2>/dev/null; then
-  run "ruff check" required python3 -m ruff check scripts/ tests/
+  RUFF_ARGS=()
+  [ "$FORMAT" = "github" ] && RUFF_ARGS+=(--output-format=github)
+  run "ruff check" required python3 -m ruff check "${RUFF_ARGS[@]}" scripts/ tests/
   run "ruff format --check" required python3 -m ruff format --check scripts/ tests/
-elif have ruff; then
-  run "ruff check" required ruff check scripts/ tests/
-  run "ruff format --check" required ruff format --check scripts/ tests/
 else
-  skip "ruff" "pip install -r requirements-dev.txt"
+  missing "ruff" "pip install -r requirements-dev.txt"
 fi
 
 # Invoke via `python3 -m` so the tests run against the same interpreter that
@@ -176,27 +215,47 @@ fi
 if python3 -c 'import pytest' 2>/dev/null; then
   run "pytest" required python3 -m pytest tests/ -q
 else
-  skip "pytest" "pip install -r requirements-dev.txt"
+  missing "pytest" "pip install -r requirements-dev.txt"
 fi
 
-INV_ARGS=(--format "$FORMAT")
-[ "$STRICT" = 1 ] && INV_ARGS+=(--strict --fail-on-warn)
+# --fail-on-warn is unconditional. Without it, WF004 (mutable internal @main),
+# WF007 (forgeable GITHUB_OUTPUT delimiter), WF008 and WF011 were advisory-only
+# in the mode CI actually runs, so a brand-new violation of any of them passed
+# the required check while the README claimed new violations fail. Baselined
+# findings are exempt by fingerprint regardless of severity, so this does not
+# resurrect the 25 accepted ones. --strict additionally ignores the baseline.
+INV_ARGS=(--format "$FORMAT" --fail-on-warn)
+[ "$STRICT" = 1 ] && INV_ARGS+=(--strict)
 run "workflow invariants" required \
   python3 scripts/check_workflow_invariants.py "${INV_ARGS[@]}"
 
+# Pinned for the same reason ruff is: a linter whose version differs between
+# local and CI enforces different rules in each. We cannot force the version of
+# an actionlint already on PATH, but we can say so out loud when it differs from
+# what CI installs, rather than letting the drift be silent.
+ACTIONLINT_VERSION="v1.7.7"
+
 if have actionlint; then
+  actual="$(actionlint --version 2>/dev/null | head -1)"
+  case "$actual" in
+    "${ACTIONLINT_VERSION#v}"|"$ACTIONLINT_VERSION") : ;;
+    *) say "${YELLOW}  note:${RESET} actionlint on PATH is ${actual:-unknown}, CI uses ${ACTIONLINT_VERSION} — findings may differ" ;;
+  esac
   run "actionlint" required actionlint -no-color -shellcheck= .github/workflows/*.yml
 elif have go && [ "$FAST" = 0 ]; then
   say "${DIM}  installing actionlint (one-off, via go install)...${RESET}"
   if GOBIN="$(go env GOPATH)/bin" go install \
-       github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 >/dev/null 2>&1; then
+       "github.com/rhysd/actionlint/cmd/actionlint@$ACTIONLINT_VERSION" >/dev/null 2>&1; then
     export PATH="$(go env GOPATH)/bin:$PATH"
     run "actionlint" required actionlint -no-color -shellcheck= .github/workflows/*.yml
   else
-    skip "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+    missing "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@$ACTIONLINT_VERSION"
   fi
+elif [ "$FAST" = 1 ]; then
+  # An explicit --fast opt-out is a choice, not an absent dependency.
+  skip "actionlint" "--fast"
 else
-  skip "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+  missing "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@$ACTIONLINT_VERSION"
 fi
 
 # zizmor is advisory: the repo currently has known findings (see
@@ -277,11 +336,22 @@ printf '  passed   %d\n' "${#PASSED[@]}"
   "${#ADVISORY[@]}" "$YELLOW" "$(IFS=', '; echo "${ADVISORY[*]}")" "$RESET"
 [ "${#SKIPPED[@]}" -gt 0 ] && printf '  skipped  %d  %s(%s)%s\n' \
   "${#SKIPPED[@]}" "$DIM" "$(IFS=', '; echo "${SKIPPED[*]}")" "$RESET"
+[ "${#MISSING[@]}" -gt 0 ] && printf '  missing  %d  %s(%s)%s\n' \
+  "${#MISSING[@]}" "$YELLOW" "$(IFS=', '; echo "${MISSING[*]}")" "$RESET"
 [ "${#FAILED[@]}" -gt 0 ] && printf '  failed   %d  %s(%s)%s\n' \
   "${#FAILED[@]}" "$RED" "$(IFS=', '; echo "${FAILED[*]}")" "$RESET"
 
 if [ "${#FAILED[@]}" -gt 0 ]; then
   printf '\n%sFAIL%s — %ds. Fix the above before committing.\n' "$RED" "$RESET" "$ELAPSED"
+  exit 1
+fi
+# A required stage that never ran is not a pass. Saying "Safe to commit" here
+# would reproduce exactly the local/CI divergence this gate exists to prevent:
+# CI installs these tools and will run those stages whether or not you did.
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  printf '\n%sINCOMPLETE%s — %ds. %d required stage(s) never ran; CI will still run them.\n' \
+    "$YELLOW" "$RESET" "$ELAPSED" "${#MISSING[@]}"
+  printf 'Install the missing tools (see hints above), or re-run with --fast to opt out explicitly.\n'
   exit 1
 fi
 printf '\n%sPASS%s — %ds. Safe to commit.\n' "$GREEN" "$RESET" "$ELAPSED"

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -283,8 +283,13 @@ if [ -n "$CDK_PROJECT" ]; then
 
     # Mirror the caller-repo invariants too — the trigger-convention and
     # secrets checks are most useful pointed at a caller.
+    # --fail-on-warn for the same reason the CI-side stage has it and the
+    # analyzer stage dropped --no-fail-on-public-access: warn-only findings would
+    # exit 0, and `run` discards the output of anything exiting 0, so WF004 and
+    # WF007 against a caller repo vanished behind a green tick. `advisory` is what
+    # keeps this from blocking; the exit code is what makes it visible.
     run "caller-repo invariants" advisory \
-      python3 scripts/check_workflow_invariants.py --path "$CDK_ABS" --strict
+      python3 scripts/check_workflow_invariants.py --path "$CDK_ABS" --strict --fail-on-warn
 
     if have cdk; then
       run "cdk synth" required in_dir "$CDK_ABS" cdk synth --quiet
@@ -357,7 +362,7 @@ fi
 if [ "${#MISSING[@]}" -gt 0 ]; then
   printf '\n%sINCOMPLETE%s — %ds. %d required stage(s) never ran; CI will still run them.\n' \
     "$YELLOW" "$RESET" "$ELAPSED" "${#MISSING[@]}"
-  printf 'Install the missing tools (see hints above), or re-run with --fast to opt out explicitly.\n'
+  printf 'Install the missing tools (see hints above). --fast opts out of actionlint\nand zizmor only; yamllint, ruff and pytest all come from requirements-dev.txt.\n'
   exit 1
 fi
 printf '\n%sPASS%s — %ds. Safe to commit.\n' "$GREEN" "$RESET" "$ELAPSED"

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# local-ci.sh — run this repo's CI gate locally, before committing.
+#
+# The CI stages mirror .github/workflows/self-test.yml so that a green run here
+# means a green run there. The CD stages are opt-in and need a target: there is
+# no way to genuinely test a deploy locally (it needs AWS and a CDK app), so
+# what they do instead is run the *checks* that cdk-review would run against a
+# real synthesized template tree.
+#
+#   ./scripts/local-ci.sh                      # the CI gate (~5s)
+#   ./scripts/local-ci.sh --fix                # ...and auto-format first
+#   ./scripts/local-ci.sh --strict             # show the baselined work list
+#   ./scripts/local-ci.sh --cdk-project ../bitwarden-cdk
+#   ./scripts/local-ci.sh --install-hook       # wire up as a pre-commit hook
+#
+# Exit 0 only if every required stage passed. Advisory stages report but never
+# block. Missing optional tools SKIP with an install hint rather than failing,
+# so a fresh clone is usable immediately.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+
+# --- options ---------------------------------------------------------------
+FAST=0 FIX=0 STRICT=0 WANT_ACT=0 CDK_PROJECT="" QUIET=0
+FORMAT="text"
+
+usage() {
+  # Print the header comment block: every leading # line after the shebang,
+  # stopping at the first line of actual code.
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' \
+    "${BASH_SOURCE[0]}"
+  cat <<'EOF'
+
+Options:
+  --fix               auto-fix what is mechanically fixable (ruff format)
+  --strict            invariants: ignore the baseline and show every finding
+  --fast              skip the slower advisory stages (zizmor)
+  --cdk-project DIR   also run the CD-side checks against a CDK project
+  --act               execute self-test.yml locally under `act` (needs Docker)
+  --format github     emit ::error/::warning annotations (for use in CI)
+  --install-hook      install this script as .git/hooks/pre-commit
+  --quiet             only print the summary and failures
+  -h, --help          this text
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fix) FIX=1 ;;
+    --strict) STRICT=1 ;;
+    --fast) FAST=1 ;;
+    --act) WANT_ACT=1 ;;
+    --quiet) QUIET=1 ;;
+    --cdk-project) CDK_PROJECT="${2:-}"; shift ;;
+    --format) FORMAT="${2:-text}"; shift ;;
+    --install-hook)
+      hook="$REPO_ROOT/.git/hooks/pre-commit"
+      mkdir -p "$(dirname "$hook")"
+      cat > "$hook" <<'HOOK'
+#!/usr/bin/env bash
+# Installed by scripts/local-ci.sh --install-hook
+exec "$(git rev-parse --show-toplevel)/scripts/local-ci.sh" --quiet
+HOOK
+      chmod +x "$hook"
+      echo "Installed pre-commit hook → $hook"
+      echo "Bypass a single commit with: git commit --no-verify"
+      exit 0
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# --- output ----------------------------------------------------------------
+if [ -t 1 ] && [ "$FORMAT" = "text" ]; then
+  BOLD=$'\033[1m'; RED=$'\033[31m'; GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+else
+  BOLD=""; RED=""; GREEN=""; YELLOW=""; DIM=""; RESET=""
+fi
+
+FAILED=() PASSED=() SKIPPED=() ADVISORY=()
+START=$SECONDS
+
+say() { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
+hdr() { say ""; say "${BOLD}── $* ${RESET}"; }
+
+# run <label> <required|advisory> <cmd...>
+# Output is shown only when a stage fails or is advisory — a passing gate should
+# be four lines, not four hundred.
+run() {
+  local label="$1" mode="$2"; shift 2
+  local out rc
+  out="$("$@" 2>&1)"; rc=$?
+  if [ $rc -eq 0 ]; then
+    PASSED+=("$label")
+    say "${GREEN}✓${RESET} $label"
+  elif [ "$mode" = advisory ]; then
+    ADVISORY+=("$label")
+    say "${YELLOW}!${RESET} $label ${DIM}(advisory — does not block)${RESET}"
+    printf '%s\n' "$out" | sed 's/^/    /'
+  else
+    FAILED+=("$label")
+    printf '%s✗%s %s\n' "$RED" "$RESET" "$label"
+    printf '%s\n' "$out" | sed 's/^/    /'
+  fi
+  return 0
+}
+
+skip() {
+  SKIPPED+=("$1")
+  say "${DIM}∅ $1 — $2${RESET}"
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Run a command in another directory. `env -C` is GNU-only; a subshell works
+# on macOS too, which is where half the devs on this repo will be.
+in_dir() { local d="$1"; shift; ( cd "$d" && "$@" ); }
+
+# zizmor prints a source excerpt per finding, which is far too much for a
+# pre-commit gate — and several of its rules (notably unpinned-uses) duplicate
+# invariants WF003/WF004, which already track those with a baseline. Collapse to
+# one line per rule with a count, so a genuinely new rule stands out.
+zizmor_brief() {
+  local out rc
+  out="$(zizmor --offline --persona=regular --format plain .github/ 2>&1)"; rc=$?
+  printf '%s\n' "$out" \
+    | grep -oE '^(error|warning|help)\[[a-z-]+\]' \
+    | sort | uniq -c | sort -rn \
+    | awk '{ printf "  %s ×%s\n", $2, $1 }'
+  printf '%s\n' "$out" | grep -E '^[0-9]+ findings' | sed 's/^/  /'
+  echo "  (detail: zizmor --offline --persona=auditor .github/)"
+  return $rc
+}
+
+# ===========================================================================
+# CI stages — these mirror .github/workflows/self-test.yml
+# ===========================================================================
+hdr "CI"
+
+if [ "$FIX" = 1 ] && have ruff; then
+  run "ruff format (--fix)" required ruff format scripts/ tests/
+fi
+
+if have yamllint; then
+  run "yamllint" required yamllint -c .yamllint.yml .github/
+else
+  skip "yamllint" "pip install -r requirements-dev.txt"
+fi
+
+if have ruff; then
+  run "ruff check" required ruff check scripts/ tests/
+  run "ruff format --check" required ruff format --check scripts/ tests/
+else
+  skip "ruff" "pip install ruff"
+fi
+
+# Invoke via `python3 -m` so the tests run against the same interpreter that
+# has boto3 installed — a bare `pytest` shim can resolve to a different one.
+if python3 -c 'import pytest' 2>/dev/null; then
+  run "pytest" required python3 -m pytest tests/ -q
+else
+  skip "pytest" "pip install -r requirements-dev.txt"
+fi
+
+INV_ARGS=(--format "$FORMAT")
+[ "$STRICT" = 1 ] && INV_ARGS+=(--strict --fail-on-warn)
+run "workflow invariants" required \
+  python3 scripts/check_workflow_invariants.py "${INV_ARGS[@]}"
+
+if have actionlint; then
+  run "actionlint" required actionlint -no-color -shellcheck= .github/workflows/*.yml
+elif have go && [ "$FAST" = 0 ]; then
+  say "${DIM}  installing actionlint (one-off, via go install)...${RESET}"
+  if GOBIN="$(go env GOPATH)/bin" go install \
+       github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 >/dev/null 2>&1; then
+    export PATH="$(go env GOPATH)/bin:$PATH"
+    run "actionlint" required actionlint -no-color -shellcheck= .github/workflows/*.yml
+  else
+    skip "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+  fi
+else
+  skip "actionlint" "go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+fi
+
+# zizmor is advisory: the repo currently has known findings (see
+# docs/reviews/2026-07-25-*.md and the invariants baseline), so a non-zero exit
+# here is expected and must not block a commit.
+if [ "$FAST" = 1 ]; then
+  skip "zizmor" "--fast"
+elif have zizmor; then
+  run "zizmor" advisory zizmor_brief
+else
+  skip "zizmor" "pip install zizmor"
+fi
+
+# ===========================================================================
+# CD stages — opt-in, need a target
+# ===========================================================================
+if [ -n "$CDK_PROJECT" ]; then
+  hdr "CD — against $CDK_PROJECT"
+  if [ ! -d "$CDK_PROJECT" ]; then
+    FAILED+=("cdk-project path")
+    printf '%s✗%s cdk-project not found: %s\n' "$RED" "$RESET" "$CDK_PROJECT"
+  else
+    CDK_ABS="$(cd "$CDK_PROJECT" && pwd)"
+    OUT="$CDK_ABS/cdk.out"
+
+    # Mirror the caller-repo invariants too — the trigger-convention and
+    # secrets checks are most useful pointed at a caller.
+    run "caller-repo invariants" advisory \
+      python3 scripts/check_workflow_invariants.py --path "$CDK_ABS" --strict
+
+    if have cdk; then
+      run "cdk synth" required in_dir "$CDK_ABS" cdk synth --quiet
+    else
+      skip "cdk synth" "npm i -g aws-cdk (or reuse an existing cdk.out)"
+    fi
+
+    if [ -d "$OUT" ]; then
+      run "bucket names (source)" required \
+        python3 scripts/validate_bucket_names.py --path "$CDK_ABS"
+      run "bucket names (templates)" required \
+        python3 scripts/validate_bucket_names.py --template-dir "$OUT"
+      # check_no_public_access calls the Access Analyzer API, so it needs real
+      # credentials. Probe first rather than emitting a traceback.
+      if have aws && aws sts get-caller-identity >/dev/null 2>&1; then
+        run "access analyzer" advisory \
+          python3 scripts/check_no_public_access.py \
+            --template-dir "$OUT" --no-fail-on-public-access
+      else
+        skip "access analyzer" "no usable AWS credentials (needs a real API call)"
+      fi
+    else
+      skip "template checks" "no cdk.out at $OUT"
+    fi
+  fi
+fi
+
+if [ "$WANT_ACT" = 1 ]; then
+  hdr "act — executing self-test.yml locally"
+  if ! have act; then
+    skip "act" "https://github.com/nektos/act#installation"
+  elif ! docker info >/dev/null 2>&1; then
+    skip "act" "Docker daemon not reachable"
+  else
+    # Only self-test.yml has a real trigger; the rest are workflow_call, which
+    # act cannot invoke standalone.
+    run "act pull_request" advisory \
+      act pull_request -W .github/workflows/self-test.yml --container-architecture linux/amd64
+  fi
+fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+ELAPSED=$((SECONDS - START))
+printf '\n%s── summary ──%s\n' "$BOLD" "$RESET"
+printf '  passed   %d\n' "${#PASSED[@]}"
+[ "${#ADVISORY[@]}" -gt 0 ] && printf '  advisory %d  %s(%s)%s\n' \
+  "${#ADVISORY[@]}" "$YELLOW" "$(IFS=', '; echo "${ADVISORY[*]}")" "$RESET"
+[ "${#SKIPPED[@]}" -gt 0 ] && printf '  skipped  %d  %s(%s)%s\n' \
+  "${#SKIPPED[@]}" "$DIM" "$(IFS=', '; echo "${SKIPPED[*]}")" "$RESET"
+[ "${#FAILED[@]}" -gt 0 ] && printf '  failed   %d  %s(%s)%s\n' \
+  "${#FAILED[@]}" "$RED" "$(IFS=', '; echo "${FAILED[*]}")" "$RESET"
+
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  printf '\n%sFAIL%s — %ds. Fix the above before committing.\n' "$RED" "$RESET" "$ELAPSED"
+  exit 1
+fi
+printf '\n%sPASS%s — %ds. Safe to commit.\n' "$GREEN" "$RESET" "$ELAPSED"
+exit 0

--- a/tests/test_check_workflow_invariants.py
+++ b/tests/test_check_workflow_invariants.py
@@ -1,0 +1,672 @@
+"""
+Tests for scripts/check_workflow_invariants.py.
+
+The point of these is negative coverage: it's easy to write a checker that
+passes on a clean tree and would also pass on a broken one. Every check gets a
+crafted violation that it must catch, plus a clean counterpart it must not flag.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_workflow_invariants.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_workflow_invariants as ci  # noqa: E402
+
+PINNED = "actions/checkout@" + "a" * 40
+
+
+def wf(body: str) -> str:
+    """Dedent at definition time so that .replace() targets in the tests match
+    the exact text that gets written — not an indented pre-image of it."""
+    return textwrap.dedent(body).lstrip()
+
+
+def write_workflow(root: Path, name: str, body: str) -> Path:
+    d = root / ".github" / "workflows"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_text(body if body[:1] not in " \n" else wf(body), encoding="utf-8")
+    return p
+
+
+def findings_for(root: Path) -> list[ci.Finding]:
+    findings, errors = ci.collect(root)
+    assert not errors, errors
+    return findings
+
+
+def checks_hit(root: Path) -> set[str]:
+    return {f.check for f in findings_for(root)}
+
+
+# A workflow that violates nothing. Every negative test starts from this and
+# breaks exactly one thing, so a test failure points at one check.
+CLEAN = wf(f"""
+    name: Clean
+    on:
+      pull_request:
+        branches: [main]
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+          contents: read
+        concurrency:
+          group: clean-${{{{ github.ref }}}}
+          cancel-in-progress: true
+        steps:
+          - uses: {PINNED}  # v5.0.0
+            with:
+              persist-credentials: false
+          - name: Do the thing
+            run: echo hello
+""")
+
+
+# Exact fragments of the final (dedented) CLEAN text. Named so a change to
+# CLEAN's shape breaks loudly in one place instead of silently no-op'ing a
+# .replace() and leaving the test passing for the wrong reason.
+PC_LINE = "          persist-credentials: false\n"
+CONCURRENCY_BLOCK = (
+    "    concurrency:\n"
+    "      group: clean-${{ github.ref }}\n"
+    "      cancel-in-progress: true\n"
+)
+PERMISSIONS_BLOCK = "    permissions:\n      contents: read\n"
+RUN_LINE = "        run: echo hello\n"
+TIMEOUT_LINE = "    timeout-minutes: 10\n"
+PR_TRIGGER = "  pull_request:\n    branches: [main]\n"
+
+
+def swap(old: str, new: str) -> str:
+    """CLEAN with `old` replaced by `new`, proving the swap took effect."""
+    assert old in CLEAN, f"fragment not present in CLEAN: {old!r}"
+    return CLEAN.replace(old, new)
+
+
+def test_clean_workflow_has_no_findings(tmp_path):
+    write_workflow(tmp_path, "clean.yml", CLEAN)
+    assert findings_for(tmp_path) == []
+
+
+def test_this_repo_has_no_blocking_findings_outside_baseline():
+    """The real gate: the committed tree must be green through the CLI."""
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_baseline_has_no_stale_entries():
+    """Every baselined fingerprint must still correspond to a real finding.
+
+    Without this, fixing an issue leaves a dead entry that would silently
+    re-accept the problem if it ever came back.
+    """
+    accepted, _ = ci.load_baseline(
+        REPO_ROOT / ".github" / "workflow-invariants-baseline.yml"
+    )
+    live = {f.fingerprint for f in findings_for(REPO_ROOT)}
+    assert accepted - live == set(), "baseline entries no longer match any finding"
+
+
+# --- WF001 timeout-minutes --------------------------------------------------
+
+
+def test_wf001_flags_job_without_timeout(tmp_path):
+    write_workflow(tmp_path, "w.yml", swap(TIMEOUT_LINE, ""))
+    assert "WF001" in checks_hit(tmp_path)
+
+
+def test_wf001_skips_job_that_only_calls_a_reusable_workflow(tmp_path):
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        """
+        name: Caller
+        on:
+          pull_request:
+            branches: [main]
+        jobs:
+          call:
+            uses: ./.github/workflows/other.yml
+        """,
+    )
+    assert "WF001" not in checks_hit(tmp_path)
+
+
+# --- WF002 persist-credentials ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        f"      - uses: {PINNED}\n",  # no with: block at all
+        f"      - uses: {PINNED}\n        with:\n          persist-credentials: true\n",
+    ],
+)
+def test_wf002_flags_checkout_leaving_credentials(tmp_path, replacement):
+    body = CLEAN.replace(
+        f"      - uses: {PINNED}  # v5.0.0\n"
+        "        with:\n"
+        "          persist-credentials: false\n",
+        replacement,
+    )
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF002" in checks_hit(tmp_path)
+
+
+# --- WF003 / WF004 pinning -------------------------------------------------
+
+
+def test_wf003_flags_unpinned_third_party_action(tmp_path):
+    write_workflow(tmp_path, "w.yml", CLEAN.replace(PINNED, "actions/checkout@v5"))
+    assert "WF003" in checks_hit(tmp_path)
+
+
+def test_wf004_flags_internal_action_at_main(tmp_path):
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        CLEAN.replace(PINNED, "Specter099/.github/.github/actions/setup-cdk@main"),
+    )
+    hit = checks_hit(tmp_path)
+    assert "WF004" in hit and "WF003" not in hit
+
+
+def test_wf004_flags_cross_repo_checkout_without_ref(tmp_path):
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        swap(PC_LINE, PC_LINE + "          repository: Specter099/.github\n"),
+    )
+    assert "WF004" in checks_hit(tmp_path)
+
+
+def test_wf004_accepts_cross_repo_checkout_with_ref(tmp_path):
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        swap(
+            PC_LINE,
+            PC_LINE
+            + "          repository: Specter099/.github\n"
+            + f"          ref: {'b' * 40}\n",
+        ),
+    )
+    assert "WF004" not in checks_hit(tmp_path)
+
+
+def test_local_action_reference_is_not_flagged(tmp_path):
+    write_workflow(tmp_path, "w.yml", CLEAN.replace(PINNED, "./.github/actions/thing"))
+    hit = checks_hit(tmp_path)
+    assert "WF003" not in hit and "WF004" not in hit
+
+
+# --- WF005 undeclared secrets ---------------------------------------------
+
+
+REUSABLE = wf("""
+    name: Reusable
+    on:
+      workflow_call:
+        inputs:
+          region:
+            type: string
+            default: us-east-1
+    jobs:
+      go:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+          contents: read
+        steps:
+          - name: Use it
+            env:
+              R: ${{ inputs.region }}
+              ROLE: ${{ secrets.AWS_ROLE_ARN }}
+            run: echo "$R $ROLE"
+""")
+
+
+def test_wf005_flags_undeclared_secret(tmp_path):
+    write_workflow(tmp_path, "r.yml", REUSABLE)
+    assert "WF005" in checks_hit(tmp_path)
+
+
+def test_wf005_accepts_declared_secret(tmp_path):
+    declared = """
+        name: Reusable
+        on:
+          workflow_call:
+            secrets:
+              AWS_ROLE_ARN:
+                required: true
+        jobs:
+          go:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - name: Use it
+                env:
+                  ROLE: ${{ secrets.AWS_ROLE_ARN }}
+                run: echo "$ROLE"
+    """
+    write_workflow(tmp_path, "r.yml", declared)
+    assert "WF005" not in checks_hit(tmp_path)
+
+
+def test_wf005_ignores_github_token(tmp_path):
+    body = """
+        name: Reusable
+        on:
+          workflow_call:
+        jobs:
+          go:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - name: Use it
+                env:
+                  T: ${{ secrets.GITHUB_TOKEN }}
+                run: echo "$T"
+    """
+    write_workflow(tmp_path, "r.yml", body)
+    assert "WF005" not in checks_hit(tmp_path)
+
+
+# --- WF006 / WF014 triggers ----------------------------------------------
+
+
+def test_wf006_flags_pull_request_target(tmp_path):
+    write_workflow(
+        tmp_path, "w.yml", CLEAN.replace("  pull_request:", "  pull_request_target:")
+    )
+    assert "WF006" in checks_hit(tmp_path)
+
+
+def test_wf014_flags_pull_request_and_push_main(tmp_path):
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        swap(PR_TRIGGER, PR_TRIGGER + "  push:\n    branches: [main]\n"),
+    )
+    assert "WF014" in checks_hit(tmp_path)
+
+
+def test_wf014_allows_push_main_alone(tmp_path):
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        swap(PR_TRIGGER, "  push:\n    branches: [main]\n"),
+    )
+    assert "WF014" not in checks_hit(tmp_path)
+
+
+# --- WF007 heredoc delimiter ---------------------------------------------
+
+
+def test_wf007_flags_fixed_eof_delimiter(tmp_path):
+    body = swap(
+        RUN_LINE, '        run: |\n          echo "diff<<EOF" >> "$GITHUB_OUTPUT"\n'
+    )
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF007" in checks_hit(tmp_path)
+
+
+def test_wf007_accepts_randomised_delimiter(tmp_path):
+    body = swap(
+        RUN_LINE,
+        "        run: |\n"
+        '          d="EOF_$(openssl rand -hex 16)"\n'
+        '          echo "diff<<$d" >> "$GITHUB_OUTPUT"\n',
+    )
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF007" not in checks_hit(tmp_path)
+
+
+# --- WF008 concurrency ---------------------------------------------------
+
+
+def test_wf008_flags_review_workflow_without_concurrency(tmp_path):
+    body = swap(CONCURRENCY_BLOCK, "")
+    write_workflow(tmp_path, "cdk-review.yml", body)
+    assert "WF008" in checks_hit(tmp_path)
+
+
+def test_wf008_ignores_non_check_workflows(tmp_path):
+    body = swap(CONCURRENCY_BLOCK, "")
+    write_workflow(tmp_path, "cdk-deploy.yml", body)
+    assert "WF008" not in checks_hit(tmp_path)
+
+
+# --- WF009 script injection ----------------------------------------------
+
+
+def test_wf009_flags_input_interpolated_into_run(tmp_path):
+    body = """
+        name: Injectable
+        on:
+          workflow_call:
+            inputs:
+              stacks:
+                type: string
+                default: "--all"
+        jobs:
+          go:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - name: Deploy
+                run: cdk deploy ${{ inputs.stacks }}
+    """
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF009" in checks_hit(tmp_path)
+
+
+def test_wf009_flags_pr_title_interpolated_into_run(tmp_path):
+    body = CLEAN.replace(
+        "        run: echo hello\n",
+        "        run: echo ${{ github.event.pull_request.title }}\n",
+    )
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF009" in checks_hit(tmp_path)
+
+
+def test_wf009_accepts_the_env_indirection_pattern(tmp_path):
+    """The fix this org uses everywhere: bind to env:, quote in the shell."""
+    body = """
+        name: Safe
+        on:
+          workflow_call:
+            inputs:
+              stacks:
+                type: string
+                default: "--all"
+        jobs:
+          go:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - name: Deploy
+                env:
+                  CDK_STACKS: ${{ inputs.stacks }}
+                run: cdk deploy "$CDK_STACKS"
+    """
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF009" not in checks_hit(tmp_path)
+
+
+# --- WF010 permissions ---------------------------------------------------
+
+
+def test_wf010_flags_job_without_permissions(tmp_path):
+    write_workflow(tmp_path, "w.yml", swap(PERMISSIONS_BLOCK, ""))
+    assert "WF010" in checks_hit(tmp_path)
+
+
+def test_wf010_accepts_workflow_level_permissions(tmp_path):
+    body = swap(PERMISSIONS_BLOCK, "").replace(
+        "jobs:\n", "permissions:\n  contents: read\njobs:\n"
+    )
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF010" not in checks_hit(tmp_path)
+
+
+# --- WF011 unused inputs -------------------------------------------------
+
+
+def test_wf011_flags_unreferenced_input(tmp_path):
+    body = """
+        name: Vestigial
+        on:
+          workflow_call:
+            inputs:
+              never-used:
+                type: string
+                default: ""
+        jobs:
+          go:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - run: echo hi
+    """
+    write_workflow(tmp_path, "w.yml", body)
+    assert "WF011" in checks_hit(tmp_path)
+
+
+def test_wf011_recognises_composite_env_var_reference(tmp_path):
+    """Composite actions can read an input as INPUT_FOO_BAR rather than
+    ${{ inputs.foo-bar }} — that still counts as a reference."""
+    d = tmp_path / ".github" / "actions" / "thing"
+    d.mkdir(parents=True)
+    (d / "action.yml").write_text(
+        textwrap.dedent(
+            """
+            name: Thing
+            description: t
+            inputs:
+              log-dir:
+                description: d
+                default: ""
+            runs:
+              using: composite
+              steps:
+                - shell: bash
+                  run: echo "$INPUT_LOG_DIR"
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    write_workflow(tmp_path, "w.yml", CLEAN)
+    assert "WF011" not in checks_hit(tmp_path)
+
+
+# --- WF012 README examples ----------------------------------------------
+
+
+def test_wf012_flags_readme_example_with_undeclared_input(tmp_path):
+    write_workflow(
+        tmp_path,
+        "python-ci.yml",
+        """
+        name: Python CI
+        on:
+          workflow_call:
+            inputs:
+              python-versions:
+                type: string
+                default: '["3.12"]'
+        jobs:
+          ci:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - name: Go
+                env:
+                  V: ${{ inputs.python-versions }}
+                run: echo "$V"
+        """,
+    )
+    (tmp_path / "README.md").write_text(
+        textwrap.dedent(
+            """
+            ```yaml
+            jobs:
+              ci:
+                uses: Specter099/.github/.github/workflows/python-ci.yml@main
+                with:
+                  python-version: "3.12"
+            ```
+            """
+        ),
+        encoding="utf-8",
+    )
+    hits = [f for f in findings_for(tmp_path) if f.check == "WF012"]
+    assert hits and "python-version" in hits[0].detail
+
+
+def test_wf012_accepts_correct_readme_example(tmp_path):
+    write_workflow(
+        tmp_path,
+        "python-ci.yml",
+        """
+        name: Python CI
+        on:
+          workflow_call:
+            inputs:
+              python-versions:
+                type: string
+                default: '["3.12"]'
+        jobs:
+          ci:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - name: Go
+                env:
+                  V: ${{ inputs.python-versions }}
+                run: echo "$V"
+        """,
+    )
+    (tmp_path / "README.md").write_text(
+        textwrap.dedent(
+            """
+            ```yaml
+            jobs:
+              ci:
+                uses: Specter099/.github/.github/workflows/python-ci.yml@main
+                with:
+                  python-versions: '["3.12"]'
+            ```
+            """
+        ),
+        encoding="utf-8",
+    )
+    assert "WF012" not in checks_hit(tmp_path)
+
+
+# --- WF013 no checks in deploy ------------------------------------------
+
+
+def test_wf013_flags_pytest_in_a_deploy_workflow(tmp_path):
+    body = swap(RUN_LINE, "        run: pytest tests/\n")
+    write_workflow(tmp_path, "cdk-deploy.yml", body)
+    assert "WF013" in checks_hit(tmp_path)
+
+
+def test_wf013_allows_npm_run_build_in_deploy(tmp_path):
+    body = swap(RUN_LINE, "        run: npm run build\n")
+    write_workflow(tmp_path, "static-site-deploy.yml", body)
+    assert "WF013" not in checks_hit(tmp_path)
+
+
+def test_wf013_ignores_review_workflows(tmp_path):
+    body = swap(RUN_LINE, "        run: pytest tests/\n")
+    write_workflow(tmp_path, "cdk-review.yml", body)
+    assert "WF013" not in checks_hit(tmp_path)
+
+
+# --- infrastructure -----------------------------------------------------
+
+
+def test_quoted_and_bare_on_key_both_parse(tmp_path):
+    """PyYAML turns a bare `on:` into the boolean True — both spellings, which
+    this repo mixes, must resolve to the same trigger block."""
+    bare = ci.triggers({True: {"workflow_call": None}})
+    quoted = ci.triggers({"on": {"workflow_call": None}})
+    assert "workflow_call" in bare and "workflow_call" in quoted
+
+
+def test_baseline_suppresses_a_finding(tmp_path):
+    write_workflow(tmp_path, "w.yml", CLEAN.replace(PINNED, "actions/checkout@v5"))
+    findings = findings_for(tmp_path)
+    target = next(f for f in findings if f.check == "WF003")
+    baseline = tmp_path / "baseline.yml"
+    baseline.write_text(
+        f'accepted:\n  - fingerprint: "{target.fingerprint}"\n', encoding="utf-8"
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--path",
+            str(tmp_path),
+            "--baseline",
+            str(baseline),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout
+    # ...and --strict must ignore the baseline and fail again.
+    strict = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--path",
+            str(tmp_path),
+            "--baseline",
+            str(baseline),
+            "--strict",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert strict.returncode == 1, strict.stdout
+
+
+def test_fingerprint_is_stable_across_line_moves(tmp_path):
+    """A finding's identity must not include the line number, or an unrelated
+    edit above it silently un-baselines it."""
+    write_workflow(tmp_path, "w.yml", CLEAN.replace(PINNED, "actions/checkout@v5"))
+    before = next(f for f in findings_for(tmp_path) if f.check == "WF003")
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        "# a new comment line\n" + CLEAN.replace(PINNED, "actions/checkout@v5"),
+    )
+    after = next(f for f in findings_for(tmp_path) if f.check == "WF003")
+    assert before.fingerprint == after.fingerprint
+    assert before.line != after.line
+
+
+def test_unparseable_yaml_is_a_hard_error(tmp_path):
+    write_workflow(tmp_path, "bad.yml", "name: [unclosed\n")
+    _findings, errors = ci.collect(tmp_path)
+    assert errors
+
+
+def test_every_check_id_has_a_rationale():
+    for cid, (sev, why) in ci.CHECKS.items():
+        assert sev in {"error", "warn"}, cid
+        assert why and len(why) < 100, cid

--- a/tests/test_check_workflow_invariants.py
+++ b/tests/test_check_workflow_invariants.py
@@ -788,7 +788,15 @@ def test_wf014_allows_push_restricted_to_other_branches(tmp_path):
 
 
 def test_gate_runs_the_checker_with_fail_on_warn():
-    """The gate must not leave warn-severity checks advisory.
+    """LOAD-BEARING — do not delete as redundant with the class-level test below.
+
+    This asserts the flag sits on the *unconditional* INV_ARGS= line. The
+    class-level test generalises across invocations, but an adversarial mutation
+    that moved --fail-on-warn into a conditional `INV_ARGS+=(...)` was caught only
+    here. The two overlap in what they cover and differ in what they can miss;
+    keep both.
+
+    The gate must not leave warn-severity checks advisory.
 
     WF004 (mutable internal @main) and WF007 (forgeable GITHUB_OUTPUT
     delimiter) are `warn`. Without --fail-on-warn they were advisory-only in
@@ -975,11 +983,22 @@ def test_no_gate_stage_mutes_a_findings_exit_code():
         """
         text = line
         for var in re.findall(r"\$\{(\w+)\[@\]\}", line):
-            text += " " + " ".join(
-                candidate
-                for candidate in lines
-                if candidate.strip().startswith((f"{var}=", f"{var}+="))
-            )
+            for candidate in lines:
+                stripped = candidate.strip()
+                if not stripped.startswith((f"{var}=", f"{var}+=")):
+                    continue
+                # Only unconditional assignments count. `[ "$X" = 1 ] && VAR+=(…)`
+                # and anything indented under an `if` apply on *some* runs, so
+                # crediting them here would be fail-open — review demonstrated a
+                # mutation that moved the flag into a conditional append and slipped
+                # past an earlier version of this check.
+                if candidate != stripped:
+                    continue  # indented → inside a block
+                if "&&" in candidate.split("=", 1)[0] or candidate.lstrip().startswith(
+                    "["
+                ):
+                    continue  # guarded by a test
+                text += " " + candidate
         return text
 
     for script, (flag, required) in muting.items():
@@ -1172,3 +1191,76 @@ def test_absent_baseline_is_not_an_error(tmp_path):
         text=True,
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+@pytest.mark.parametrize(
+    "value,expect",
+    [
+        ("main", True),  # scalar string: invalid per schema, common typo
+        (["main"], True),
+        (5, False),  # non-iterable: must not raise
+        (True, False),
+        ([None], False),
+        ([["main"]], False),  # nested list: stringified, no crash
+    ],
+)
+def test_branch_filter_normalisation_never_raises(value, expect):
+    """A scalar `branches: main` used to iterate characters and return False —
+    the opposite of intent — and `branches: 5` raised TypeError. Both are
+    invalid workflow files, but a checker should not crash on one."""
+    assert ci._push_fires_on_main({"push": {"branches": value}}) is expect
+
+
+def test_conditional_array_append_does_not_satisfy_the_class_level_test(tmp_path):
+    """The class-level guard must not credit a flag that only applies sometimes.
+
+    Adversarial review moved --fail-on-warn from the unconditional INV_ARGS= line
+    into a guarded `INV_ARGS+=(...)` and the earlier effective_args() treated it as
+    unconditional, letting the mutation through.
+    """
+    fake = tmp_path / "gate.sh"
+    fake.write_text(
+        'INV_ARGS=(--format "$FORMAT")\n'
+        '[ "$STRICT" = 1 ] && INV_ARGS+=(--fail-on-warn)\n'
+        'python3 scripts/check_workflow_invariants.py "${INV_ARGS[@]}"\n',
+        encoding="utf-8",
+    )
+    lines = fake.read_text(encoding="utf-8").splitlines()
+
+    def effective_args(line: str) -> str:
+        text = line
+        for var in re.findall(r"\$\{(\w+)\[@\]\}", line):
+            for candidate in lines:
+                stripped = candidate.strip()
+                if not stripped.startswith((f"{var}=", f"{var}+=")):
+                    continue
+                if candidate != stripped:
+                    continue
+                if "&&" in candidate.split("=", 1)[0] or candidate.lstrip().startswith(
+                    "["
+                ):
+                    continue
+                text += " " + candidate
+        return text
+
+    invocation = next(
+        effective_args(line)
+        for line in lines
+        if "check_workflow_invariants.py" in line and "python3" in line
+    )
+    assert "--fail-on-warn" not in invocation, (
+        "a conditionally-appended flag must not count as unconditionally present"
+    )
+
+
+def test_gate_runs_yamllint_in_strict_mode():
+    """yamllint exits 0 on warning-level findings, and run() discards the output
+    of anything exiting 0 — the same muted-findings shape as the two blocking
+    bugs, just inside a third-party tool's own pass contract. --strict makes
+    warnings count."""
+    yamllint_lines = [line for line in GATE.splitlines() if "YAMLLINT_ARGS=(" in line]
+    assert yamllint_lines, "expected the gate to build YAMLLINT_ARGS"
+    assert any("--strict" in line for line in yamllint_lines), (
+        "yamllint must run --strict or warning-level findings exit 0 and are "
+        f"discarded. Found: {yamllint_lines}"
+    )

--- a/tests/test_check_workflow_invariants.py
+++ b/tests/test_check_workflow_invariants.py
@@ -670,3 +670,162 @@ def test_every_check_id_has_a_rationale():
     for cid, (sev, why) in ci.CHECKS.items():
         assert sev in {"error", "warn"}, cid
         assert why and len(why) < 100, cid
+
+
+# ---------------------------------------------------------------------------
+# Regression guards for the bypasses found in adversarial review of PR #138.
+# Each of these passed the checker before the fix, so they are the tests that
+# would have caught the gap.
+# ---------------------------------------------------------------------------
+
+
+def _caller(uses: str) -> str:
+    """A workflow whose only job is a reusable-workflow call."""
+    return wf(f"""
+        name: Caller
+        on:
+          pull_request:
+            branches: [main]
+        jobs:
+          call:
+            uses: {uses}
+            secrets: inherit
+    """)
+
+
+def test_wf003_flags_unpinned_third_party_reusable_workflow_call(tmp_path):
+    """Job-level `uses:` was invisible to the step walk, so an unpinned
+    third-party reusable workflow — the one composition that can carry
+    `secrets: inherit` — passed even under --strict --fail-on-warn."""
+    write_workflow(
+        tmp_path,
+        "c.yml",
+        _caller("some-rando/malicious/.github/workflows/pwn.yml@main"),
+    )
+    hits = [f for f in findings_for(tmp_path) if f.check == "WF003"]
+    assert hits, "unpinned third-party reusable workflow call not flagged"
+    assert "reusable workflow call" in hits[0].detail
+
+
+def test_wf004_flags_internal_reusable_workflow_call_at_main(tmp_path):
+    write_workflow(
+        tmp_path,
+        "c.yml",
+        _caller("Specter099/.github/.github/workflows/python-ci.yml@main"),
+    )
+    hit = checks_hit(tmp_path)
+    assert "WF004" in hit and "WF003" not in hit
+
+
+def test_sha_pinned_reusable_workflow_call_is_accepted(tmp_path):
+    write_workflow(
+        tmp_path, "c.yml", _caller(f"some-org/repo/.github/workflows/x.yml@{'c' * 40}")
+    )
+    hit = checks_hit(tmp_path)
+    assert "WF003" not in hit and "WF004" not in hit
+
+
+def test_local_reusable_workflow_call_is_accepted(tmp_path):
+    write_workflow(tmp_path, "c.yml", _caller("./.github/workflows/other.yml"))
+    hit = checks_hit(tmp_path)
+    assert "WF003" not in hit and "WF004" not in hit
+
+
+def _triggers_wf(on_block: str) -> str:
+    return wf(f"""
+        name: S
+        {on_block}
+        jobs:
+          s:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            permissions:
+              contents: read
+            steps:
+              - run: echo hi
+    """)
+
+
+def test_wf014_flags_bare_push_with_no_branch_filter(tmp_path):
+    """`push:` with no filter fires on every branch including main, so it
+    double-runs at merge just like `push: {branches: [main]}`."""
+    write_workflow(
+        tmp_path,
+        "s.yml",
+        _triggers_wf(
+            "on:\n          pull_request:\n            branches: [main]\n          push:"
+        ),
+    )
+    assert "WF014" in checks_hit(tmp_path)
+
+
+def test_wf014_flags_list_form_triggers(tmp_path):
+    """`on: [pull_request, push]` — the list form maps push to None."""
+    write_workflow(tmp_path, "s.yml", _triggers_wf("on: [pull_request, push]"))
+    assert "WF014" in checks_hit(tmp_path)
+
+
+def test_wf014_allows_push_restricted_to_other_branches(tmp_path):
+    """An explicit filter that excludes main is the legitimate case."""
+    write_workflow(
+        tmp_path,
+        "s.yml",
+        _triggers_wf(
+            "on:\n          pull_request:\n            branches: [main]\n"
+            "          push:\n            branches: [release/**]"
+        ),
+    )
+    assert "WF014" not in checks_hit(tmp_path)
+
+
+def test_gate_runs_the_checker_with_fail_on_warn():
+    """The gate must not leave warn-severity checks advisory.
+
+    WF004 (mutable internal @main) and WF007 (forgeable GITHUB_OUTPUT
+    delimiter) are `warn`. Without --fail-on-warn they were advisory-only in
+    the mode self-test.yml runs, so a brand-new violation of either passed the
+    required check while the README promised new violations fail. This asserts
+    the flag is unconditional rather than tied to --strict.
+    """
+    gate = (REPO_ROOT / "scripts" / "local-ci.sh").read_text(encoding="utf-8")
+    inv_line = next(
+        line for line in gate.splitlines() if line.strip().startswith("INV_ARGS=(")
+    )
+    assert "--fail-on-warn" in inv_line, (
+        "local-ci.sh must pass --fail-on-warn unconditionally; found: " + inv_line
+    )
+
+
+def test_warn_findings_block_once_fail_on_warn_is_set(tmp_path):
+    """End-to-end via the CLI: a warn-only finding is exit 0 by default and
+    exit 1 with --fail-on-warn, so the gate's flag is what makes it bite."""
+    write_workflow(
+        tmp_path,
+        "cdk-review.yml",
+        swap(PINNED, "Specter099/.github/.github/actions/setup-cdk@main"),
+    )
+    base = [sys.executable, str(SCRIPT), "--path", str(tmp_path)]
+    lenient = subprocess.run(base, capture_output=True, text=True)
+    strict = subprocess.run([*base, "--fail-on-warn"], capture_output=True, text=True)
+    assert lenient.returncode == 0, lenient.stdout
+    assert strict.returncode == 1, strict.stdout
+
+
+def test_wf014_flags_push_dict_without_a_branches_key(tmp_path):
+    """`push:` as a mapping with only a path/tag filter and no `branches:` still
+    fires on every branch, main included — a PR touching src/** runs the check,
+    then the merge push to main runs it again.
+
+    Distinct from the bare `push:` case above: that one parses to None and takes
+    the non-mapping path. This one is a dict whose `branches` is absent, and
+    mutation testing showed the bare-push test did not cover it.
+    """
+    write_workflow(
+        tmp_path,
+        "s.yml",
+        _triggers_wf(
+            "on:\n          pull_request:\n            branches: [main]\n"
+            "          push:\n            paths: ['src/**']"
+        ),
+    )
+    assert "WF014" in checks_hit(tmp_path)

--- a/tests/test_check_workflow_invariants.py
+++ b/tests/test_check_workflow_invariants.py
@@ -8,6 +8,7 @@ crafted violation that it must catch, plus a clean counterpart it must not flag.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import textwrap
@@ -112,16 +113,23 @@ def test_this_repo_has_no_blocking_findings_outside_baseline():
 
 
 def test_baseline_has_no_stale_entries():
-    """Every baselined fingerprint must still correspond to a real finding.
+    """Every baselined fingerprint must still correspond to a real finding, and
+    no entry may accept more findings than actually exist.
 
-    Without this, fixing an issue leaves a dead entry that would silently
-    re-accept the problem if it ever came back.
+    Without the first half, fixing an issue leaves a dead entry that would
+    silently re-accept the problem if it came back. Without the second, an
+    inflated `count` is a blank cheque for future duplicates.
     """
     accepted, _ = ci.load_baseline(
         REPO_ROOT / ".github" / "workflow-invariants-baseline.yml"
     )
-    live = {f.fingerprint for f in findings_for(REPO_ROOT)}
-    assert accepted - live == set(), "baseline entries no longer match any finding"
+    live: dict[str, int] = {}
+    for f in findings_for(REPO_ROOT):
+        live[f.fingerprint] = live.get(f.fingerprint, 0) + 1
+    stale = set(accepted) - set(live)
+    assert stale == set(), f"baseline entries match no finding: {sorted(stale)}"
+    over = {fp: (n, live[fp]) for fp, n in accepted.items() if n > live[fp]}
+    assert over == {}, f"baseline accepts more than exist (accepted, live): {over}"
 
 
 # --- WF001 timeout-minutes --------------------------------------------------
@@ -829,3 +837,202 @@ def test_wf014_flags_push_dict_without_a_branches_key(tmp_path):
         ),
     )
     assert "WF014" in checks_hit(tmp_path)
+
+
+# --- round-2 regression guards ---------------------------------------------
+
+
+def test_wf014_allows_tags_only_push(tmp_path):
+    """`push: {tags: [...]}` never fires on a branch push, so there is no
+    merge-time double-run. This is the common "PR checks + tag release" caller
+    layout, and flagging it was a false positive on an error-severity check."""
+    write_workflow(
+        tmp_path,
+        "s.yml",
+        _triggers_wf(
+            "on:\n          pull_request:\n            branches: [main]\n"
+            "          push:\n            tags: ['v*']"
+        ),
+    )
+    assert "WF014" not in checks_hit(tmp_path)
+
+
+def test_wf014_allows_branches_ignore_main(tmp_path):
+    write_workflow(
+        tmp_path,
+        "s.yml",
+        _triggers_wf(
+            "on:\n          pull_request:\n            branches: [main]\n"
+            "          push:\n            branches-ignore: [main]"
+        ),
+    )
+    assert "WF014" not in checks_hit(tmp_path)
+
+
+@pytest.mark.parametrize("pattern", ["m*", "**", "mai?", "*"])
+def test_wf014_flags_glob_branch_patterns_matching_main(tmp_path, pattern):
+    """Branch filters are globs. An exact-string membership test missed
+    `branches: ["m*"]`, which does fire on main."""
+    write_workflow(
+        tmp_path,
+        "s.yml",
+        _triggers_wf(
+            "on:\n          pull_request:\n            branches: [main]\n"
+            f"          push:\n            branches: ['{pattern}']"
+        ),
+    )
+    assert "WF014" in checks_hit(tmp_path)
+
+
+def test_baseline_count_stops_a_duplicate_new_violation(tmp_path):
+    """A second, genuinely new violation that happens to share a fingerprint
+    with a baselined one must still block.
+
+    Two identical `echo "x<<EOF"` lines in one file produce the same
+    check+path+detail, so a set-based baseline absorbed the new one silently.
+    """
+    body = swap(
+        RUN_LINE,
+        '        run: |\n          echo "diff<<EOF" >> "$GITHUB_OUTPUT"\n',
+    )
+    write_workflow(tmp_path, "w.yml", body)
+    one = [f for f in findings_for(tmp_path) if f.check == "WF007"]
+    assert len(one) == 1
+    fp = one[0].fingerprint
+
+    baseline = tmp_path / "b.yml"
+    baseline.write_text(f'accepted:\n  - fingerprint: "{fp}"\n', encoding="utf-8")
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--path",
+        str(tmp_path),
+        "--baseline",
+        str(baseline),
+        "--fail-on-warn",
+    ]
+
+    # One occurrence, budget of one → accepted.
+    assert subprocess.run(cmd, capture_output=True, text=True).returncode == 0
+
+    # Add a second identical occurrence → the budget is spent, so it blocks.
+    write_workflow(
+        tmp_path,
+        "w.yml",
+        body.replace(
+            '          echo "diff<<EOF" >> "$GITHUB_OUTPUT"\n',
+            '          echo "diff<<EOF" >> "$GITHUB_OUTPUT"\n'
+            '          echo "diff<<EOF" >> "$GITHUB_OUTPUT"\n',
+        ),
+    )
+    assert len([f for f in findings_for(tmp_path) if f.check == "WF007"]) == 2
+    second = subprocess.run(cmd, capture_output=True, text=True)
+    assert second.returncode == 1, second.stdout
+
+    # An explicit count of 2 accepts both, so the escape hatch still exists.
+    baseline.write_text(
+        f'accepted:\n  - fingerprint: "{fp}"\n    count: 2\n', encoding="utf-8"
+    )
+    assert subprocess.run(cmd, capture_output=True, text=True).returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# The gate's advisory contract.
+#
+# `run()` prints ✓ and DISCARDS the output of anything exiting 0. So a stage
+# whose findings matter must signal them with a non-zero exit — otherwise the
+# gate renders a detected problem as an affirmative green tick. This bit the
+# CD access-analyzer stage, which passed --no-fail-on-public-access (making the
+# script exit 0 on violations) while running in advisory mode.
+# ---------------------------------------------------------------------------
+
+GATE = (REPO_ROOT / "scripts" / "local-ci.sh").read_text(encoding="utf-8")
+
+
+def test_gate_does_not_mute_the_access_analyzer_exit_code():
+    """--no-fail-on-public-access + advisory run() = green tick over a real
+    finding, with the findings text thrown away. `advisory` already guarantees
+    the stage cannot block, so the exit code must stay meaningful."""
+    analyzer_lines = [
+        line for line in GATE.splitlines() if "check_no_public_access.py" in line
+    ]
+    assert analyzer_lines, "expected the CD stage to invoke check_no_public_access.py"
+    invocation = " ".join(analyzer_lines)
+    assert "--no-fail-on-public-access" not in invocation, (
+        "the gate must not suppress the analyzer's exit code; advisory mode "
+        "already prevents it from blocking. Found: " + invocation
+    )
+
+
+def test_advisory_stages_only_show_output_on_nonzero_exit():
+    """Pins the run() behaviour the test above depends on, so a future change to
+    run() that swallowed non-zero output would surface here rather than silently
+    invalidating the reasoning."""
+    body = GATE.split("run() {", 1)[1].split("\n}", 1)[0]
+    zero_branch = body.split("elif", 1)[0]
+    # The rc==0 path must not print captured output...
+    assert "$out" not in zero_branch, (
+        "run() now prints output on success; the advisory reasoning above needs "
+        "revisiting"
+    )
+    # ...while the advisory path must.
+    advisory_branch = body.split("elif", 1)[1].split("else", 1)[0]
+    assert "$out" in advisory_branch
+
+
+def test_check_no_public_access_exit_code_depends_on_the_flag(tmp_path, monkeypatch):
+    """The underlying behaviour that made the flag dangerous in an advisory
+    stage: with it, violations exit 0; without it, they exit 1."""
+    import check_no_public_access as cnpa
+
+    (tmp_path / "S.template.json").write_text(
+        json.dumps(
+            {
+                "Resources": {
+                    "BP": {
+                        "Type": "AWS::S3::BucketPolicy",
+                        "Properties": {
+                            "PolicyDocument": {
+                                "Version": "2012-10-17",
+                                "Statement": [
+                                    {
+                                        "Effect": "Allow",
+                                        "Principal": "*",
+                                        "Action": "s3:GetObject",
+                                        "Resource": "arn:aws:s3:::b/*",
+                                    }
+                                ],
+                            }
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeAnalyzer:
+        def check_no_public_access(self, **_kw):
+            return {"result": "FAIL", "reasons": [{"description": "public"}]}
+
+    class FakeSts:
+        def get_caller_identity(self):
+            return {"Account": "123456789012"}
+
+    monkeypatch.setattr(
+        cnpa.boto3,
+        "client",
+        lambda name, **_kw: FakeSts() if name == "sts" else FakeAnalyzer(),
+    )
+
+    def run_with(argv):
+        monkeypatch.setattr(
+            "sys.argv", ["prog", "--template-dir", str(tmp_path), *argv]
+        )
+        return cnpa.main()
+
+    assert run_with([]) == 1, "violations must be a non-zero exit by default"
+    assert run_with(["--no-fail-on-public-access"]) == 0, (
+        "the flag is what makes violations exit 0 — which is why an advisory "
+        "stage must not pass it"
+    )

--- a/tests/test_check_workflow_invariants.py
+++ b/tests/test_check_workflow_invariants.py
@@ -9,6 +9,7 @@ crafted violation that it must catch, plus a clean counterpart it must not flag.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 import textwrap
@@ -949,6 +950,60 @@ def test_baseline_count_stops_a_duplicate_new_violation(tmp_path):
 GATE = (REPO_ROOT / "scripts" / "local-ci.sh").read_text(encoding="utf-8")
 
 
+def test_no_gate_stage_mutes_a_findings_exit_code():
+    """Class-level guard, not instance-level.
+
+    Both blocking bugs in adversarial review were the same shape: a stage that
+    reported a real finding while exiting 0, so `run()` printed ✓ and discarded
+    the output. It happened twice — once with --no-fail-on-public-access on the
+    analyzer stage, then again with a missing --fail-on-warn on the caller-repo
+    invariants stage — because the first fix addressed the instance. This asserts
+    the property over *every* invocation of either script in the gate.
+    """
+    muting = {
+        "check_no_public_access.py": ("--no-fail-on-public-access", False),
+        "check_workflow_invariants.py": ("--fail-on-warn", True),
+    }
+    lines = GATE.splitlines()
+
+    def effective_args(line: str) -> str:
+        """The line's arguments, following one level of array indirection.
+
+        The CI-side stage passes its flags via "${INV_ARGS[@]}", so checking the
+        invocation line alone would wrongly report it as unflagged. Resolve any
+        referenced array to the lines that build it.
+        """
+        text = line
+        for var in re.findall(r"\$\{(\w+)\[@\]\}", line):
+            text += " " + " ".join(
+                candidate
+                for candidate in lines
+                if candidate.strip().startswith((f"{var}=", f"{var}+="))
+            )
+        return text
+
+    for script, (flag, required) in muting.items():
+        invocations = [
+            effective_args(line)
+            for line in lines
+            if script in line and "python3" in line
+        ]
+        assert invocations, f"expected the gate to invoke {script}"
+        for inv in invocations:
+            if required:
+                # The invariants checker is silent-on-warn unless told otherwise,
+                # so every gate invocation must opt in.
+                assert flag in inv, (
+                    f"{script} invoked without {flag}; warn-severity findings "
+                    f"would exit 0 and be discarded by run(). Line: {inv}"
+                )
+            else:
+                assert flag not in inv, (
+                    f"{script} invoked with {flag}; violations would exit 0 and "
+                    f"be discarded by run(). Line: {inv}"
+                )
+
+
 def test_gate_does_not_mute_the_access_analyzer_exit_code():
     """--no-fail-on-public-access + advisory run() = green tick over a real
     finding, with the findings text thrown away. `advisory` already guarantees
@@ -1036,3 +1091,84 @@ def test_check_no_public_access_exit_code_depends_on_the_flag(tmp_path, monkeypa
         "the flag is what makes violations exit 0 — which is why an advisory "
         "stage must not pass it"
     )
+
+
+# --- round-3 regression guards ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "branches,expect_flag",
+    [
+        ("['**', '!main']", False),  # negation excludes main → no double-run
+        ("['!main']", False),
+        ("['**']", True),
+        ("['release/**', '!release/old']", False),  # main matches nothing
+        ("['!dev', '**']", True),  # later positive re-includes main
+    ],
+)
+def test_wf014_honours_negated_branch_patterns(tmp_path, branches, expect_flag):
+    """GitHub branch filters support `!` negation with later entries overriding
+    earlier ones, so ['**', '!main'] means every branch except main."""
+    write_workflow(
+        tmp_path,
+        "s.yml",
+        _triggers_wf(
+            "on:\n          pull_request:\n            branches: [main]\n"
+            f"          push:\n            branches: {branches}"
+        ),
+    )
+    assert ("WF014" in checks_hit(tmp_path)) is expect_flag
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "accepted: [ unclosed",  # not valid YAML
+        "- just\n- a\n- list\n",  # top level not a mapping
+        'accepted:\n  - fingerprint: "x"\n    count: banana\n',  # count not an int
+        'accepted:\n  - fingerprint: "x"\n    count: 0\n',  # a zero budget
+        'accepted:\n  - fingerprint: "x"\n    count: -5\n',  # negative
+    ],
+)
+def test_malformed_baseline_exits_two_without_a_traceback(tmp_path, content):
+    """A broken baseline must fail closed *and* legibly. Exit 2 is the
+    documented "could not run"; a traceback is correct-but-unreadable, and
+    silently ignoring the file would accept nothing while burying the reason."""
+    write_workflow(tmp_path, "w.yml", CLEAN)
+    baseline = tmp_path / "b.yml"
+    baseline.write_text(content, encoding="utf-8")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--path",
+            str(tmp_path),
+            "--baseline",
+            str(baseline),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2, (proc.returncode, proc.stdout, proc.stderr)
+    assert "Traceback" not in proc.stderr, proc.stderr
+    assert "error:" in proc.stderr, proc.stderr
+
+
+def test_absent_baseline_is_not_an_error(tmp_path):
+    """A caller repo with no baseline at all is the normal case, not a failure —
+    every finding is simply unaccepted."""
+    write_workflow(tmp_path, "w.yml", CLEAN)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--path",
+            str(tmp_path),
+            "--baseline",
+            str(tmp_path / "does-not-exist.yml"),
+            "--fail-on-warn",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr


### PR DESCRIPTION
## Summary

Two related changes across 3 commits. The first is the report; the second turns the machine-checkable half of it into a gate that runs before you commit.

> **Note:** this PR started as docs-only and grew a second part. The description has been rewritten to match the actual diff (10 files, +2247/−6) rather than the original single commit.

### 1. The review — `docs/reviews/2026-07-25-actions-security-efficiency-review.md`

A review of all 11 reusable workflows, the 3 composite actions, both helper scripts, and `dependabot.yml`: 14 security items (S1–S14) and 15 efficiency items (E1–E15), each with `file:line` references, plus documentation drift and a suggested sequencing order. Cross-checked with `zizmor --persona=auditor` (36 findings, 12 high).

**Credit where due:** third-party actions are SHA-pinned, `persist-credentials: false` is on every checkout, every job has a `timeout-minutes`, caller inputs go through `env:` rather than `${{ }}` inside `run:`, and `github-script` reads the CDK diff from `process.env`. The items already closed in `TODO.md` hold up.

The four that matter:

1. **S1 — review workflows hold AWS credentials while executing PR-authored code.** `cdk-review` assumes the OIDC role, then runs `pip install -r requirements.txt`, `cdk synth`, and `cdk diff` from the PR head. `static-site-review` adds `npm ci` / `npm run build`. Fix: a distinct least-privilege review role, subject-scoped OIDC trust policy, `role-duration-seconds: 900`, and splitting the job so dependency install and tests run uncredentialed.
2. **S2 — `cdk-review` can report success having checked nothing.** The job declares no `environment:`, but the README documents `AWS_ROLE_ARN` as an *environment* secret on `production`. Under the documented setup the secret resolves empty, all six `if: env.AWS_ROLE_ARN != ''` steps skip, and the job exits 0 with a warning — a required check green with no synth, diff, Nag, or Access Analyzer. `static-site-review` fails loudly in the same situation; the two disagree, and the silent one is the one branch protection relies on.
3. **S3 — `tee`'d logs bypass secret masking.** Redaction happens in the runner as it processes the output stream; `tee` forks a copy before that point, so the shipped files are unredacted. Worst case is `cdk deploy --verbose`.
4. **S4 — four workflows force callers into `secrets: inherit`** by referencing `secrets.AWS_ROLE_ARN` without declaring a `workflow_call.secrets:` block.

### 2. The gate — `scripts/local-ci.sh`

One entrypoint, ~2–3s. `self-test.yml` now calls the same script, so local and CI cannot drift.

```bash
./scripts/local-ci.sh              # yamllint, ruff, pytest, invariants, actionlint; zizmor advisory
./scripts/local-ci.sh --fix        # format first
./scripts/local-ci.sh --strict     # show the baselined work list
./scripts/local-ci.sh --install-hook
./scripts/local-ci.sh --cdk-project ../bitwarden-cdk
```

Missing optional tools (`actionlint`, `zizmor`, `act`, `cdk`) skip with an install hint rather than failing, so a fresh clone works immediately.

**On the CD side:** a deploy cannot be genuinely rehearsed locally — it needs AWS and a real CDK app. `--cdk-project` instead runs the checks `cdk-review` would run against a real synthesized tree: `cdk synth`, bucket-name validation over both Python source and templates, then Access Analyzer, which needs live credentials and skips with a notice when `aws sts get-caller-identity` fails.

**`scripts/check_workflow_invariants.py`** — 14 checks (WF001–WF014) for the conventions no off-the-shelf linter covers: undeclared `workflow_call` secrets, unpinned internal actions, cross-repo checkout with no `ref`, `pull_request_target`, fixed `GITHUB_OUTPUT` heredoc delimiters, untrusted context interpolated into `run:`, missing concurrency on PR checks, checks leaking into deploy workflows, the `pull_request` + `push:main` double-run, and README examples passing inputs that don't exist. It independently reproduced S4 and the README `python-version` bug. `--path` points it at a caller repo, where it catches the trigger violations tracked in `TODO.md` P0.

Pre-existing findings are accepted in `.github/workflow-invariants-baseline.yml`, which cites the review finding behind each entry — a work list, not a suppression list. Deleting an entry claims the fix; new violations fail even while old ones are tolerated; a test asserts no stale entries.

## Type of change

- [x] Bug fix — `ruff` version divergence between local and CI (commit 3)
- [ ] New feature
- [ ] Breaking change
- [x] Infrastructure / CI change — `self-test.yml` now runs `scripts/local-ci.sh`; adds `ruff.toml`
- [x] Documentation — the review report, plus README/CLAUDE.md updates

## Checklist

- [x] I have tested these changes locally (or explained why that isn't possible) — see verification below.
- [x] I have updated documentation where relevant — README gains a "Local development" section; CLAUDE.md gains the commands and a corrected Code Style section (it claimed there was no Python formatter config, which is no longer true).
- [x] CI checks (lint, tests, synth/diff, security scans) pass — `Lint & Test` green on `b478a3e`.
- [x] No secrets, credentials, or account IDs are hardcoded — secret *names* only; the placeholder account ID `123456789012` already appears in the repo's own examples.

## Verification

- 87 tests pass (48 pre-existing + 39 new).
- **Mutation-tested the checker** rather than trusting green tests: disabling each of the 13 invariant code paths fails at least one test, so the negative coverage is real. My first attempt was invalid — a failed `git checkout` on an untracked file left a mutation baked into the working copy, contaminating every result — and was redone from a clean copy with a green-baseline assertion.
- CD path exercised against a synthetic caller project with a non-conforming bucket name in both source and template; both caught, Access Analyzer correctly skipped for want of credentials.
- Gate verified in a clean venv built only from `requirements-dev.txt` with only that venv on `PATH`.

**I broke CI once here, in exactly the way this gate exists to prevent.** `ruff check` passed locally and failed with 22 findings in CI: a `PATH`-shadowed ruff 0.15.8 locally versus the pip-installed 0.16.0 in CI, which enables a broader default rule set. Fixed in commit 3 by invoking `python3 -m ruff`, pinning `ruff==0.16.0`, and adding `ruff.toml` to declare the rule set explicitly. Verified causally: without the config the pinned 0.16.0 reports 22 errors; with it the tree is clean.

## Not verified

- **No finding in the report was checked against a live workflow run.** S2 especially is worth confirming against a recent `cdk-review` run log — a green check that skipped synth/diff would be visible there, and that should drive how urgently it's fixed.
- Two fixes are reasoned rather than tested: the bash 3.2 `set -u` empty-array abort (macOS `/bin/bash`), addressed by removing the dependency rather than by claiming a test; and `actionlint`'s `go install` fallback, which worked in CI but would silently skip on a runner without Go.
- The report deliberately changes no workflow behaviour. Every S/E finding remains open and baselined.

## Related issues

None. Overlaps `TODO.md`: still-open P0 (internal `@main` pinning, caller trigger conventions — the checker now detects both), P1, P2 (npm cache key, Checkov claim), and P3. The four lead findings are new.