### PR TITLE
fix: grant id-token/contents permissions to backup workflow caller job

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -7,6 +7,14 @@ on:
 
 jobs:
   backup:
+    # With restricted default workflow permissions, a reusable workflow's job
+    # requesting id-token: write fails at startup unless the caller job
+    # explicitly grants it - this job wasn't granting anything, so every run
+    # since this workflow started calling repo-backup.yml has failed before
+    # any job was even scheduled.
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/repo-backup.yml
     with:
       s3-bucket: ${{ vars.BACKUP_S3_BUCKET }}


### PR DESCRIPTION
## Summary
- Since #141 rewrote `backup.yml` to call `repo-backup.yml` as a local reusable workflow (`uses: ./.github/workflows/repo-backup.yml`), every run has failed with `startup_failure` and **zero jobs scheduled** — confirmed via a manual `workflow_dispatch` run just now (run [30201103186](https://github.com/Specter099/.github/actions/runs/30201103186)).
- Root cause: with restricted default workflow permissions, a reusable workflow's job requesting `id-token: write` (needed for OIDC) fails validation at startup unless the *caller* job explicitly grants it. The caller job here granted nothing.
- Adds the same `permissions: {id-token: write, contents: read}` block already used by every cross-repo caller of this same reusable workflow (e.g. `ssmtree`, `static-site-infra`).

## Test plan
- [x] `actionlint` and `yamllint -c .yamllint.yml` pass
- [x] `python scripts/check_workflow_invariants.py` shows no new findings
- [ ] After merge, trigger `workflow_dispatch` on `backup.yml` and confirm the `backup` job actually schedules and completes (previously not covered by this PR's diff — the org-wide OIDC trust gap for this repo, fixed separately in `github-oidc-stackset-template#64`, must also be merged/deployed for the run to fully succeed end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)