### PR TITLE
docs: make org PR template more accessible to screen reader users

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary
 
-<!-- What does this PR change, and why? -->
+*Describe what this PR changes and why.*
 
 ## Type of change
 
@@ -12,11 +12,11 @@
 
 ## Checklist
 
-- [ ] I have tested these changes locally (or explained why that isn't possible)
+- [ ] I have tested these changes locally, or explained why that isn't possible
 - [ ] I have updated documentation where relevant
-- [ ] CI checks (lint, tests, synth/diff, security scans) pass
-- [ ] No secrets, credentials, or account IDs are hardcoded
+- [ ] I confirm CI checks (lint, tests, synth/diff, security scans) pass
+- [ ] I confirm no secrets, credentials, or account IDs are hardcoded
 
 ## Related issues
 
-<!-- Link related issues, e.g. "Closes #123" -->
+*Link related issues, e.g. "Closes #123".*


### PR DESCRIPTION
- Replace HTML-comment placeholders with plain italicized text: GitHub
  pre-fills the PR description textarea with the raw template, and
  screen readers reading that textarea speak the literal <!-- --> comment
  syntax aloud as noise.
- Rephrase checklist items to consistent first-person, parallel
  construction ("I confirm ...") so each item reads predictably on its
  own when navigated line by line.