### PR TITLE
feat: accept AWS_ROLE_ARN as a caller variable, not only a secret

### DIFF
--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -24,10 +24,16 @@ on:
         description: >-
           IAM role ARN for OIDC federation. Optional: callers migrated to a
           per-repo OIDC role supply the ARN as an AWS_ROLE_ARN repository
-          VARIABLE instead, which the step below falls back to. Left
-          required, a migrated caller's `secrets: inherit` would have
-          nothing to pass and the run would fail on the missing required
-          secret before any expression was evaluated.
+          VARIABLE instead, which the step below falls back to.
+
+          Declared optional because the declaration should describe what is
+          actually true - a migrated caller has no such secret to pass.
+          Whether GitHub would have ENFORCED `required: true` against a
+          caller using `secrets: inherit` is not settled: the documentation
+          does not say, and reports differ on whether inherit skips
+          required-secret validation and resolves the missing value to an
+          empty string. Optional is correct either way; do not restore
+          `required: true` on the assumption that it was only decorative.
         required: false
   workflow_dispatch:
     inputs:
@@ -104,16 +110,25 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
-          # Secret first, variable second - deliberately, and in that order.
-          # GitHub resolves a secret ahead of a same-named variable anyway,
-          # so this preserves today's behaviour exactly for every caller
-          # that still has the secret, while letting a caller migrate on its
-          # own schedule: deleting its AWS_ROLE_ARN secret is what switches
-          # it to its per-repo role. No flag day, and re-adding the secret
-          # reverts it.
+          # Secret first, variable second. `secrets` and `vars` are separate
+          # contexts with no precedence between them - the ordering in this
+          # `||` is the ONLY thing that makes the secret win, so do not
+          # reorder it. That ordering is what preserves today's behaviour
+          # exactly for every caller that still has a secret, while letting
+          # a caller migrate on its own schedule: deleting its AWS_ROLE_ARN
+          # secret is what switches it to its per-repo role. No flag day,
+          # and re-adding the secret reverts it.
+          #
+          # "Deleting its secret" means at EVERY scope. This job binds to an
+          # environment, and an environment secret shadows a repository
+          # secret of the same name, so a caller holding both that deletes
+          # only the repository one keeps running on the old shared role -
+          # green, and not migrated.
           #
           # `vars` here resolves against the CALLER's repository, not this
-          # one. See terraform-personal/MIGRATION_PLAN.md in github-as-code.
+          # one: "For reusable workflows, the variables from the caller
+          # workflow's repository are used."
+          # https://docs.github.com/en/actions/learn-github-actions/variables
           role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 

--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -128,7 +128,7 @@ jobs:
           # `vars` here resolves against the CALLER's repository, not this
           # one: "For reusable workflows, the variables from the caller
           # workflow's repository are used."
-          # https://docs.github.com/en/actions/learn-github-actions/variables
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
           role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 

--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -21,8 +21,14 @@ on:
         default: "backup"
     secrets:
       AWS_ROLE_ARN:
-        description: IAM role ARN for OIDC federation
-        required: true
+        description: >-
+          IAM role ARN for OIDC federation. Optional: callers migrated to a
+          per-repo OIDC role supply the ARN as an AWS_ROLE_ARN repository
+          VARIABLE instead, which the step below falls back to. Left
+          required, a migrated caller's `secrets: inherit` would have
+          nothing to pass and the run would fail on the missing required
+          secret before any expression was evaluated.
+        required: false
   workflow_dispatch:
     inputs:
       s3-bucket:
@@ -81,10 +87,34 @@ jobs:
           SIZE=$(du -sh "$FILENAME" | cut -f1)
           echo "ARCHIVE_SIZE=$SIZE" >> "$GITHUB_ENV"
 
+      # Now that the secret is optional, "neither is set" is a reachable
+      # misconfiguration - a caller that deleted its secret before its
+      # AWS_ROLE_ARN variable existed. Without this the run dies inside
+      # configure-aws-credentials on an empty role, which reads like an AWS
+      # permissions problem rather than a missing input.
+      - name: Verify a role ARN is available
+        env:
+          ROLE_ARN: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
+        run: |
+          if [ -z "$ROLE_ARN" ]; then
+            echo "::error::No AWS_ROLE_ARN available. Set it as a repository variable in the calling repo (per-repo OIDC role), or as a secret it passes via 'secrets: inherit'." >&2
+            exit 1
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          # Secret first, variable second - deliberately, and in that order.
+          # GitHub resolves a secret ahead of a same-named variable anyway,
+          # so this preserves today's behaviour exactly for every caller
+          # that still has the secret, while letting a caller migrate on its
+          # own schedule: deleting its AWS_ROLE_ARN secret is what switches
+          # it to its per-repo role. No flag day, and re-adding the secret
+          # reverts it.
+          #
+          # `vars` here resolves against the CALLER's repository, not this
+          # one. See terraform-personal/MIGRATION_PLAN.md in github-as-code.
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN || vars.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: Upload to S3


### PR DESCRIPTION
Unblocks the per-repo OIDC role migration for the 16 repos whose only AWS use is this workflow.

## Why

Those repos consume their role ARN solely through `repo-backup.yml` via `secrets: inherit`. Migrating them onto per-repo OIDC roles means the ARN arrives as a Terraform-managed repository **variable**, not a secret — so this workflow has to accept both.

## What changed

- `role-to-assume` falls back to `vars.AWS_ROLE_ARN`. **Secret first**, so behaviour is unchanged for every caller that still has one.
- `AWS_ROLE_ARN` becomes `required: false`. This is the part the fallback expression alone would not have covered: a required *secret* input cannot be satisfied by a variable, so once a migrated caller deletes its secret, `secrets: inherit` has nothing to pass and the run fails on the missing required secret **before any expression is evaluated**.
- Added a guard for "neither is set". That became reachable the moment the secret stopped being required, and `configure-aws-credentials` reports an empty role as what looks like an AWS permissions failure rather than a missing input.

## Blast radius

Both changes are no-ops while the callers' secrets exist — GitHub resolves a secret ahead of a same-named variable anyway. Nothing changes for any caller until that caller's secret is deleted, which is the deliberate per-repo cutover switch, and re-adding the secret reverts it.

## Verification

Not yet proven live: that a caller's `vars.AWS_ROLE_ARN` resolves inside this reusable workflow. `ssmtree` is the pilot for exactly that (Specter099/github-as-code, `feat/oidc-terraform-combined-cutover`). Do not migrate the other 15 until that run is green.

Context: `terraform-personal/MIGRATION_PLAN.md` → "Combined cutover" in github-as-code.