### PR TITLE
feat(setup-cdk): let callers point Node at a version file

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -1,7 +1,22 @@
 name: Setup CDK
-description: Install Python 3.12, Node 22, pinned CDK CLI, and Python dependencies
+description: Install Python 3.12, Node (22 by default), pinned CDK CLI, and Python dependencies
 
 inputs:
+  node-version-file:
+    description: >-
+      Path to a version file (`.nvmrc`, `.node-version`) relative to the repo
+      root. Takes precedence over `node-version`, so a repo that keeps an
+      `.nvmrc` for local development gets the same Node here without stating
+      the version twice. Must exist when set, or setup-node fails.
+    required: false
+    default: ""
+  node-version:
+    description: >-
+      Node version to install. Ignored when `node-version-file` is set. Falls
+      back to the default below if empty, which is the version this action is
+      tested against.
+    required: false
+    default: ""
   cdk-version:
     description: >-
       CDK CLI version. Composite actions cannot read the `vars` context,
@@ -32,9 +47,29 @@ runs:
         python-version: "3.12"
         cache: pip
 
+    # Exactly one of the two reaches setup-node: given both, it honours
+    # node-version and ignores the file, so the unused one must come through
+    # empty. That cannot be expressed inline — `X && '' || Y` yields Y, because
+    # an empty string is falsy — so resolve it here, as the CDK version is.
+    - name: Resolve Node version
+      id: node-ver
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.node-version-file }}
+        INPUT_VER: ${{ inputs.node-version }}
+      run: |
+        if [ -n "$INPUT_FILE" ]; then
+          echo "file=$INPUT_FILE" >> "$GITHUB_OUTPUT"
+          echo "version=" >> "$GITHUB_OUTPUT"
+        else
+          echo "file=" >> "$GITHUB_OUTPUT"
+          echo "version=${INPUT_VER:-22}" >> "$GITHUB_OUTPUT"
+        fi
+
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
-        node-version: "22"
+        node-version-file: ${{ steps.node-ver.outputs.file }}
+        node-version: ${{ steps.node-ver.outputs.version }}
 
     - name: Cache npm
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0

--- a/.github/workflows/static-site-deploy.yml
+++ b/.github/workflows/static-site-deploy.yml
@@ -30,6 +30,14 @@ on:
           hardcoded default in the setup-cdk action.
         type: string
         default: ""
+      node-version-file:
+        description: >-
+          Path to a Node version file (`.nvmrc`, `.node-version`) relative to
+          the repo root, e.g. `frontend/.nvmrc`. Set this so the version the
+          frontend is developed against is the one CI runs, instead of the two
+          drifting apart silently. Empty/unset keeps the setup-cdk default.
+        type: string
+        default: ""
       smoke-test-url:
         description: URL to curl after deploy for smoke test (optional)
         type: string
@@ -93,6 +101,7 @@ jobs:
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
           cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
+          node-version-file: ${{ inputs.node-version-file }}
           requirements-path: ${{ inputs.infra-dir }}/requirements.txt
 
       - name: Install frontend dependencies

--- a/.github/workflows/static-site-review.yml
+++ b/.github/workflows/static-site-review.yml
@@ -26,6 +26,14 @@ on:
           hardcoded default in the setup-cdk action.
         type: string
         default: ""
+      node-version-file:
+        description: >-
+          Path to a Node version file (`.nvmrc`, `.node-version`) relative to
+          the repo root, e.g. `frontend/.nvmrc`. Set this so the version the
+          frontend is developed against is the one CI runs, instead of the two
+          drifting apart silently. Empty/unset keeps the setup-cdk default.
+        type: string
+        default: ""
       smoke-test-url:
         description: Unused in review — accepted for interface consistency with deploy workflow
         type: string
@@ -89,6 +97,7 @@ jobs:
         uses: Specter099/.github/.github/actions/setup-cdk@main
         with:
           cdk-version: ${{ inputs.cdk-version != '' && inputs.cdk-version || vars.CDK_CLI_VERSION }}
+          node-version-file: ${{ inputs.node-version-file }}
           requirements-path: ${{ inputs.infra-dir }}/requirements.txt
 
       - name: Install frontend dependencies


### PR DESCRIPTION
## Correcting the premise first

While reviewing scissors-website I claimed CI "rides whatever Node `ubuntu-latest` ships." **That was wrong.** Node *is* pinned — `actions/setup-node` with `node-version: "22"` lives inside the `setup-cdk` composite action, which is why it does not appear in a grep of the reusable workflow files.

The real gap is narrower, and still worth closing.

## The problem

The pin is hardcoded in one place no calling repo can see or override. A repo that keeps an `.nvmrc` for local development has no way to make CI honour it, so the two drift apart silently. The symptom is the worst kind: **a suite that is green in CI and broken on a developer's machine.**

That is not hypothetical — it just happened. `scissors-website`'s frontend tests failed 10 cases on a developer's Node 26 while CI stayed green on 22, because Node 26 ships a global `localStorage` that shadows jsdom's. Nobody noticed until someone ran the suite locally.

## The change

- **`setup-cdk`** gains `node-version-file` and `node-version` inputs. Both default to empty and fall back to `"22"`, so **every existing caller is unaffected with no edit**.
- **`static-site-review.yml` / `static-site-deploy.yml`** gain a `node-version-file` passthrough — these are the workflows whose callers have a frontend.
- **`cdk-review.yml` / `cdk-deploy.yml` deliberately left alone.** Their Node only runs the CDK CLI; letting a repo point that at an arbitrary version buys nothing and risks running the CLI on something untested. Easy to add later if a need appears.

## Why a resolve step and not an inline expression

`setup-node` honours `node-version` over `node-version-file` when both arrive, so the unused one must reach it **empty**. That cannot be expressed inline:

```
node-version: ${{ inputs.node-version-file != '' && '' || (inputs.node-version != '' && inputs.node-version || '22') }}
```

An empty string is falsy in GitHub expressions, so `true && ''` is falsy and the whole thing falls through to `'22'` — meaning the file would be passed **and then ignored**, silently. I wrote that version first and caught it while tracing the cases, not after. Resolution now happens in a shell step, mirroring the `Resolve CDK version` step already in this action.

## Verification

Simulated the resolve script across all four input combinations:

| `node-version-file` | `node-version` | → `file` | → `version` |
| --- | --- | --- | --- |
| — | — | *(empty)* | `22` |
| `fe/.nvmrc` | — | `fe/.nvmrc` | *(empty)* |
| — | `20` | *(empty)* | `20` |
| `fe/.nvmrc` | `20` | `fe/.nvmrc` | *(empty)* |

Row 1 is the regression that matters: unchanged default for every current caller.

`./scripts/local-ci.sh` → **PASS** (yamllint, ruff check, ruff format, pytest, workflow invariants, actionlint). zizmor's findings are pre-existing repo-wide; this change adds no new `uses:` lines.

## Follow-up

Once this merges, `scissors-website` can pass `node-version-file: scissors-hair-barber/.nvmrc` in its two workflows, making the `.nvmrc` added in Specter099/scissors-website#81 the single source of truth instead of advisory documentation. That is a one-line change per workflow, in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfTSPLQYc4hkaQD7Yws2ap